### PR TITLE
Port tutorial notebooks to pyCC 4

### DIFF
--- a/AdvancedPif-4.ipynb
+++ b/AdvancedPif-4.ipynb
@@ -1,0 +1,700 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# The PIF structure\n",
+    "The Physical Information File (PIF) is a __general__, __flexible__, and __hierachical__ schema for representing infomation about physical devices and materials. This enables the PIF to store a wide range of information on many kinds of physical systems, but requires more careful thought on where to store information within the schema.\n",
+    "\n",
+    "\n",
+    "Full documentation is available at [citrine.io/pif](citrine.io/pif)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "source": [
+    "* The PIF focuses on information specific to physical systems, but is sufficiently __general__ to handle a wide range of systems.\n",
+    "* The PIF does not impose a rigid schema, and instead is __flexible__ in exactly where data is stored\n",
+    "* The PIF has a __hierarchical__ structure can store information on multiple levels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## System\n",
+    "\n",
+    "A system is the primary building block in a PIF record. Systems contain three general categories of information relevant to physical systems:\n",
+    "\n",
+    "* Identifiers - What is this?\n",
+    "\n",
+    "* Preparation - How was this made?\n",
+    "\n",
+    "* Properties - How does this perform and what are its characteristics?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"category\": \"system.chemical\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pypif import pif\n",
+    "from pypif.obj import *\n",
+    "\n",
+    "my_pif = ChemicalSystem()\n",
+    "\n",
+    "print( pif.dumps(my_pif, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Identifiers\n",
+    "What is this?\n",
+    "* Formula, composition, name\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"category\": \"system.chemical\",\n",
+      "    \"chemicalFormula\": \"Li0.0024Ni0.9976O\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_pif.chemical_formula = \"Li0.0024Ni0.9976O\"\n",
+    "\n",
+    "print( pif.dumps(my_pif, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Preparation\n",
+    "How was this made?\n",
+    "* Processing information"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"category\": \"system.chemical\",\n",
+      "    \"chemicalFormula\": \"Li0.0024Ni0.9976O\",\n",
+      "    \"processing\": [\n",
+      "        {\n",
+      "            \"name\": \"Route\",\n",
+      "            \"details\": [\n",
+      "                {\n",
+      "                    \"name\": \"Solid state reaction\"\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "route = ProcessStep(name=\"Route\")\n",
+    "route.details = [Value(name=\"Solid state reaction\")]\n",
+    "\n",
+    "my_pif.processing = [route]\n",
+    "\n",
+    "print( pif.dumps(my_pif, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Properties\n",
+    "How does this perform and what are its characteristics?\n",
+    "* Properties, measurement conditions\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"properties\": [\n",
+      "        {\n",
+      "            \"name\": \"Crystallinity\",\n",
+      "            \"scalars\": \"Polycrystalline\"\n",
+      "        },\n",
+      "        {\n",
+      "            \"name\": \"Resistivity\",\n",
+      "            \"scalars\": [\n",
+      "                28.8677,\n",
+      "                0.2629,\n",
+      "                0.0466\n",
+      "            ],\n",
+      "            \"units\": \"\\\\Ohm*cm\",\n",
+      "            \"conditions\": [\n",
+      "                {\n",
+      "                    \"name\": \"Temperature\",\n",
+      "                    \"scalars\": [\n",
+      "                        400,\n",
+      "                        700,\n",
+      "                        1000\n",
+      "                    ],\n",
+      "                    \"units\": \"K\"\n",
+      "                }\n",
+      "            ]\n",
+      "        },\n",
+      "        {\n",
+      "            \"name\": \"Power factor\",\n",
+      "            \"scalars\": [\n",
+      "                0.000121,\n",
+      "                0.0166,\n",
+      "                0.148\n",
+      "            ],\n",
+      "            \"units\": \"W/mK\",\n",
+      "            \"conditions\": [\n",
+      "                {\n",
+      "                    \"name\": \"Temperature\",\n",
+      "                    \"scalars\": [\n",
+      "                        400,\n",
+      "                        700,\n",
+      "                        1000\n",
+      "                    ],\n",
+      "                    \"units\": \"K\"\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ],\n",
+      "    \"category\": \"system.chemical\",\n",
+      "    \"chemicalFormula\": \"Li0.0024Ni0.9976O\",\n",
+      "    \"processing\": [\n",
+      "        {\n",
+      "            \"name\": \"Route\",\n",
+      "            \"details\": [\n",
+      "                {\n",
+      "                    \"name\": \"Solid state reaction\"\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "crystallinity = Property(name=\"Crystallinity\", scalars=\"Polycrystalline\")\n",
+    "resistivity = Property(name=\"Resistivity\", units=\"\\Ohm*cm\", scalars=[28.8677, 0.2629, 0.0466])\n",
+    "resistivity.conditions = [Value(name=\"Temperature\", units=\"K\", scalars=[400, 700, 1000])]\n",
+    "\n",
+    "power_factor = Property(name=\"Power factor\", units=\"W/mK\", scalars=[1.21E-4, 1.66E-2, 1.48E-1])\n",
+    "power_factor.conditions = [Value(name=\"Temperature\", units=\"K\", scalars=[400, 700, 1000])]\n",
+    "\n",
+    "my_pif.properties = [crystallinity, resistivity, power_factor]\n",
+    "\n",
+    "print( pif.dumps(my_pif, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Reference information\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"references\": [\n",
+      "        {\n",
+      "            \"doi\": \"10.1143/JJAP.38.L1336\"\n",
+      "        }\n",
+      "    ],\n",
+      "    \"properties\": [\n",
+      "        {\n",
+      "            \"name\": \"Crystallinity\",\n",
+      "            \"scalars\": \"Polycrystalline\"\n",
+      "        },\n",
+      "        {\n",
+      "            \"name\": \"Resistivity\",\n",
+      "            \"scalars\": [\n",
+      "                28.8677,\n",
+      "                0.2629,\n",
+      "                0.0466\n",
+      "            ],\n",
+      "            \"units\": \"\\\\Ohm*cm\",\n",
+      "            \"conditions\": [\n",
+      "                {\n",
+      "                    \"name\": \"Temperature\",\n",
+      "                    \"scalars\": [\n",
+      "                        400,\n",
+      "                        700,\n",
+      "                        1000\n",
+      "                    ],\n",
+      "                    \"units\": \"K\"\n",
+      "                }\n",
+      "            ]\n",
+      "        },\n",
+      "        {\n",
+      "            \"name\": \"Power factor\",\n",
+      "            \"scalars\": [\n",
+      "                0.000121,\n",
+      "                0.0166,\n",
+      "                0.148\n",
+      "            ],\n",
+      "            \"units\": \"W/mK\",\n",
+      "            \"conditions\": [\n",
+      "                {\n",
+      "                    \"name\": \"Temperature\",\n",
+      "                    \"scalars\": [\n",
+      "                        400,\n",
+      "                        700,\n",
+      "                        1000\n",
+      "                    ],\n",
+      "                    \"units\": \"K\"\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ],\n",
+      "    \"category\": \"system.chemical\",\n",
+      "    \"chemicalFormula\": \"Li0.0024Ni0.9976O\",\n",
+      "    \"processing\": [\n",
+      "        {\n",
+      "            \"name\": \"Route\",\n",
+      "            \"details\": [\n",
+      "                {\n",
+      "                    \"name\": \"Solid state reaction\"\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_pif.references = [Reference(doi=\"10.1143/JJAP.38.L1336\")]\n",
+    "\n",
+    "print( pif.dumps(my_pif, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Hierarchical\n",
+    "* Subsystems"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"name\": \"Thermoelectric module\",\n",
+      "    \"category\": \"system\",\n",
+      "    \"subsystems\": [\n",
+      "        {\n",
+      "            \"references\": [\n",
+      "                {\n",
+      "                    \"doi\": \"10.1143/JJAP.38.L1336\"\n",
+      "                }\n",
+      "            ],\n",
+      "            \"properties\": [\n",
+      "                {\n",
+      "                    \"name\": \"Crystallinity\",\n",
+      "                    \"scalars\": \"Polycrystalline\"\n",
+      "                },\n",
+      "                {\n",
+      "                    \"name\": \"Resistivity\",\n",
+      "                    \"scalars\": [\n",
+      "                        28.8677,\n",
+      "                        0.2629,\n",
+      "                        0.0466\n",
+      "                    ],\n",
+      "                    \"units\": \"\\\\Ohm*cm\",\n",
+      "                    \"conditions\": [\n",
+      "                        {\n",
+      "                            \"name\": \"Temperature\",\n",
+      "                            \"scalars\": [\n",
+      "                                400,\n",
+      "                                700,\n",
+      "                                1000\n",
+      "                            ],\n",
+      "                            \"units\": \"K\"\n",
+      "                        }\n",
+      "                    ]\n",
+      "                },\n",
+      "                {\n",
+      "                    \"name\": \"Power factor\",\n",
+      "                    \"scalars\": [\n",
+      "                        0.000121,\n",
+      "                        0.0166,\n",
+      "                        0.148\n",
+      "                    ],\n",
+      "                    \"units\": \"W/mK\",\n",
+      "                    \"conditions\": [\n",
+      "                        {\n",
+      "                            \"name\": \"Temperature\",\n",
+      "                            \"scalars\": [\n",
+      "                                400,\n",
+      "                                700,\n",
+      "                                1000\n",
+      "                            ],\n",
+      "                            \"units\": \"K\"\n",
+      "                        }\n",
+      "                    ]\n",
+      "                }\n",
+      "            ],\n",
+      "            \"category\": \"system.chemical\",\n",
+      "            \"chemicalFormula\": \"Li0.0024Ni0.9976O\",\n",
+      "            \"processing\": [\n",
+      "                {\n",
+      "                    \"name\": \"Route\",\n",
+      "                    \"details\": [\n",
+      "                        {\n",
+      "                            \"name\": \"Solid state reaction\"\n",
+      "                        }\n",
+      "                    ]\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "thermoelectric_module = System(name=\"Thermoelectric module\")\n",
+    "thermoelectric_module.subsystems = [my_pif]\n",
+    "\n",
+    "print( pif.dumps(thermoelectric_module, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Citrination metadata\n",
+    "Citrination identifiers for querying and navigation\n",
+    "* UID, Tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"tags\": [\n",
+      "        \"my_second_upload\"\n",
+      "    ],\n",
+      "    \"references\": [\n",
+      "        {\n",
+      "            \"doi\": \"10.1143/JJAP.38.L1336\"\n",
+      "        }\n",
+      "    ],\n",
+      "    \"uid\": \"my-pif\",\n",
+      "    \"properties\": [\n",
+      "        {\n",
+      "            \"name\": \"Crystallinity\",\n",
+      "            \"scalars\": \"Polycrystalline\"\n",
+      "        },\n",
+      "        {\n",
+      "            \"name\": \"Resistivity\",\n",
+      "            \"scalars\": [\n",
+      "                28.8677,\n",
+      "                0.2629,\n",
+      "                0.0466\n",
+      "            ],\n",
+      "            \"units\": \"\\\\Ohm*cm\",\n",
+      "            \"conditions\": [\n",
+      "                {\n",
+      "                    \"name\": \"Temperature\",\n",
+      "                    \"scalars\": [\n",
+      "                        400,\n",
+      "                        700,\n",
+      "                        1000\n",
+      "                    ],\n",
+      "                    \"units\": \"K\"\n",
+      "                }\n",
+      "            ]\n",
+      "        },\n",
+      "        {\n",
+      "            \"name\": \"Power factor\",\n",
+      "            \"scalars\": [\n",
+      "                0.000121,\n",
+      "                0.0166,\n",
+      "                0.148\n",
+      "            ],\n",
+      "            \"units\": \"W/mK\",\n",
+      "            \"conditions\": [\n",
+      "                {\n",
+      "                    \"name\": \"Temperature\",\n",
+      "                    \"scalars\": [\n",
+      "                        400,\n",
+      "                        700,\n",
+      "                        1000\n",
+      "                    ],\n",
+      "                    \"units\": \"K\"\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ],\n",
+      "    \"category\": \"system.chemical\",\n",
+      "    \"chemicalFormula\": \"Li0.0024Ni0.9976O\",\n",
+      "    \"processing\": [\n",
+      "        {\n",
+      "            \"name\": \"Route\",\n",
+      "            \"details\": [\n",
+      "                {\n",
+      "                    \"name\": \"Solid state reaction\"\n",
+      "                }\n",
+      "            ]\n",
+      "        }\n",
+      "    ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_pif.uid = \"my-pif\"\n",
+    "my_pif.tags = [\"my_second_upload\"]\n",
+    "\n",
+    "print( pif.dumps(my_pif, indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "### creating a dataset\n",
+    "\n",
+    "If you have been completing the API Example tutorials in the order in which they're presented on [Citrination.org/learn](https://citrination.org/learn/api-examples/), feel free to use the dataset id you created previously. Otherwise, the cell below will use the `citrination_client` to create a new dataset and corresponding `dataset_id`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "160722\n"
+     ]
+    }
+   ],
+   "source": [
+    "#comment this cell if you have an ID from a dataset you created via the website\n",
+    "\n",
+    "import random\n",
+    "import string\n",
+    "import json\n",
+    "\n",
+    "from citrination_client import CitrinationClient\n",
+    "from os import environ\n",
+    "\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')\n",
+    "\n",
+    "\n",
+    "#the following lines create a dataset to use throughout the tutorial notebooks\n",
+    "random_string = ''.join([random.choice(string.ascii_uppercase + string.digits) for i in range(5)])\n",
+    "dataset_name = \"Tutorial dataset \" + random_string\n",
+    "\n",
+    "dataset = client.data.create_dataset(name=dataset_name, description=\"Dataset for tutorial\", public=False)\n",
+    "\n",
+    "#your dataset_id will be stored here\n",
+    "dataset_id = dataset._id\n",
+    "print(dataset_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_failures': [], '_successes': [{'path': 'example_data/pif.json'}]}"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "filename = \"example_data/pif.json\"\n",
+    "with open(filename, 'w') as fp:\n",
+    "    pif.dump(my_pif, fp)\n",
+    "result = client.data.upload(dataset_id, filename)\n",
+    "result.__dict__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Once uploaded, a PIF can be viewed at the url http://citrination.com/pifs/{dataset_id}/{version_number}/{uid}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/AdvancedQueries-4.ipynb
+++ b/AdvancedQueries-4.ipynb
@@ -1,0 +1,508 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Query structure mirrors pif structure\n",
+    "* You can query subsystems, processing steps, properties, conditions of properties etc. by creating a query that matches the object hierarchy to the section you want to query\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "from citrination_client import PifSystemReturningQuery, PifSystemQuery, FieldQuery, ValueQuery\n",
+    "from citrination_client import PropertyQuery, DataQuery, DatasetQuery, ChemicalFieldQuery, ChemicalFilter, Filter\n",
+    "\n",
+    "from os import environ\n",
+    "from pypif import pif\n",
+    "\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Flattening the PIF structure\n",
+    "\n",
+    "extract_as creates a flattened dictionary structure mapping user supplied keys to objects in the PIF that match within the query\n",
+    "\n",
+    "extract_all is an option for extract_as that pulls a list of all objects at the level in the hierarchy that match the query\n",
+    "\n",
+    "Let's search for the \"Enthalpy of Formation\" property:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "69640 hits\n",
+      "\n",
+      "Extracted fields:\n",
+      "{\n",
+      "  \"formation_enthalpy\": [\n",
+      "    \"0.0\"\n",
+      "  ]\n",
+      "}\n",
+      "{\n",
+      "  \"formation_enthalpy\": [\n",
+      "    \"0.1074050600000005\"\n",
+      "  ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset_id = 150675\n",
+    "query_size = 10\n",
+    "\n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=query_size,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(dataset_id))]\n",
+    "                ),\n",
+    "                chemical_formula=ChemicalFieldQuery(\n",
+    "                    extract_as='formula',\n",
+    "                    filter=ChemicalFilter(\n",
+    "                            equal='CdTe')),\n",
+    "                system=PifSystemQuery(\n",
+    "                    properties=PropertyQuery(\n",
+    "                        extract_all=True,\n",
+    "                        name=FieldQuery(\n",
+    "                            filter=[Filter(equal=\"Enthalpy of Formation\")]),\n",
+    "                        value=FieldQuery(\n",
+    "                            extract_as=\"formation_enthalpy\",\n",
+    "                            extract_all=True)\n",
+    "                    )\n",
+    "                )\n",
+    "            ))\n",
+    "\n",
+    "query_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\\n\".format(query_result.total_num_hits))\n",
+    "print( \"Extracted fields:\")\n",
+    "for i in range(2):\n",
+    "    print( pif.dumps(query_result.hits[i].extracted, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Chemical formula search\n",
+    "Citrine has developed specialized search functionality specifically for chemical formulas. The analyser parses the search string and recognizes chemical entities such as elements and stoichiometries to find chemically relevant results.\n",
+    "\n",
+    "1. You can use a `simple_chemical_search` with a simple search string like \"PbSe\" or,\n",
+    "2. You can structure a `PifSystemReturningQuery` with more detailed elemental and stoichiometric strings.\n",
+    "\n",
+    "Let's search over the Materials Project dataset using ```mp_dataset_id = 150675``` as the dataset_id."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Citrination Client Warning - Query size greater than max system size - only 10000 results will be returned\n",
+      "4 hits \n",
+      "\n",
+      "{\"property_units\": \"g/cm$^3$\", \"name\": \"Lead selenide - HP\", \"property_value\": \"8.767862185821011\", \"chemical_formula\": \"PbSe\", \"property_name\": \"Density\"}\n",
+      "\n",
+      "\n",
+      "{\"property_units\": \"g/cm$^3$\", \"name\": \"Lead selenide\", \"property_value\": \"4.062929739915243\", \"chemical_formula\": \"PbSe\", \"property_name\": \"Density\"}\n",
+      "\n",
+      "\n",
+      "{\"property_units\": \"g/cm$^3$\", \"name\": \"Clausthalite\", \"property_value\": \"7.872521935843158\", \"chemical_formula\": \"PbSe\", \"property_name\": \"Density\"}\n",
+      "\n",
+      "\n",
+      "{\"property_units\": \"g/cm$^3$\", \"name\": \"Nickel lead selenide (3/2/2)\", \"property_value\": \"9.207453481307569\", \"chemical_formula\": \"Ni3(PbSe)2\", \"property_name\": \"Density\"}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "mp_dataset_id = 150675\n",
+    "query = client.search.generate_simple_chemical_query(chemical_formula=\"PbSe\", include_datasets=[mp_dataset_id])\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits \\n\".format(search_result.total_num_hits))\n",
+    "\n",
+    "for i in range(search_result.total_num_hits):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted))\n",
+    "    print(\"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's explore the different filters we can apply to chemical formulas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "69640 hits\n",
+      "{\"formula\": [\"Na(FeO2)2\"]}\n",
+      "{\"formula\": [\"CaV(SiO3)2\"]}\n",
+      "{\"formula\": [\"LuAgSn\"]}\n",
+      "{\"formula\": [\"La4C2Cl5\"]}\n",
+      "{\"formula\": [\"Li3V3(BO5)2\"]}\n",
+      "23 hits\n",
+      "{\"formula\": [\"Ga(MoSe2)4\"]}\n",
+      "{\"formula\": [\"Ga(MoSe2)4\"]}\n",
+      "{\"formula\": [\"Ga\"]}\n",
+      "{\"formula\": [\"GaS\"]}\n",
+      "{\"formula\": [\"Ga\"]}\n",
+      "33017 hits\n",
+      "{\"formula\": [\"Pr2NCl3\"]}\n",
+      "{\"formula\": [\"K7TaAs4\"]}\n",
+      "{\"formula\": [\"Er(MnGe)2\"]}\n",
+      "{\"formula\": [\"GdMnGe\"]}\n",
+      "{\"formula\": [\"Rb(MoS)3\"]}\n",
+      "1577 hits\n",
+      "{\"formula\": [\"CuO\"]}\n",
+      "{\"formula\": [\"ZrO2\"]}\n",
+      "{\"formula\": [\"SiO2\"]}\n",
+      "{\"formula\": [\"Fe3O4\"]}\n",
+      "{\"formula\": [\"SiO2\"]}\n",
+      "121 hits\n",
+      "{\"formula\": [\"CuO\"]}\n",
+      "{\"formula\": [\"NbO\"]}\n",
+      "{\"formula\": [\"FeO\"]}\n",
+      "{\"formula\": [\"RbO\"]}\n",
+      "{\"formula\": [\"TiO\"]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=5,\n",
+    "            random_results=True,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(mp_dataset_id))]\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_all=True,\n",
+    "                        extract_as='formula'),\n",
+    "                    )\n",
+    "                )\n",
+    "            )\n",
+    "\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\".format(search_result.total_num_hits))\n",
+    "for i in range(5):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted))\n",
+    "    \n",
+    "\n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=5,\n",
+    "            random_results=True,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(mp_dataset_id))]\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_all=True,\n",
+    "                        extract_as='formula',\n",
+    "                        filter=ChemicalFilter(\n",
+    "                            equal='Ga')\n",
+    "                    )\n",
+    "                )\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\".format(search_result.total_num_hits))\n",
+    "for i in range(5):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted))\n",
+    "\n",
+    "\n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=5,\n",
+    "            random_results=True,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(mp_dataset_id))]\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_all=True,\n",
+    "                        extract_as='formula',\n",
+    "                        filter=ChemicalFilter(\n",
+    "                            equal='?x?y?z')\n",
+    "                    )\n",
+    "                )\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\".format(search_result.total_num_hits))\n",
+    "for i in range(5):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted))\n",
+    "\n",
+    "\n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=5,\n",
+    "            random_results=True,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(mp_dataset_id))]\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_all=True,\n",
+    "                        extract_as='formula',\n",
+    "                        filter=ChemicalFilter(\n",
+    "                            equal='?xOy')\n",
+    "                    )\n",
+    "                )\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\".format(search_result.total_num_hits))\n",
+    "for i in range(5):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted))\n",
+    "    \n",
+    "\n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=5,\n",
+    "            random_results=True,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(mp_dataset_id))]\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_all=True,\n",
+    "                        extract_as='formula',\n",
+    "                        filter=ChemicalFilter(\n",
+    "                            equal='?1O1')\n",
+    "                    )\n",
+    "                )\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\".format(search_result.total_num_hits))\n",
+    "for i in range(5):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Logical operations\n",
+    "\n",
+    "We can also include the following logical operations on the filters: `SHOULD, MUST, OPTIONAL, MUST_NOT`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1456 hits\n",
+      "\n",
+      "{\"formula\": \"Tb5O9\"}\n",
+      "{\"formula\": \"TiO2\"}\n",
+      "{\"formula\": \"HoO3\"}\n",
+      "{\"formula\": \"VO2\"}\n",
+      "{\"formula\": \"P2O3\"}\n",
+      "69640 hits\n",
+      "\n",
+      "{\n",
+      "  \"crystal system\": \"trigonal\",\n",
+      "  \"bandgap\": \"3.5443000000000002\",\n",
+      "  \"formula\": \"Si2Mo4P6O25\",\n",
+      "  \"H_f\": \"-2.6705706557609394\"\n",
+      "}\n",
+      "{\n",
+      "  \"crystal system\": \"triclinic\",\n",
+      "  \"bandgap\": \"0.6514000000000006\",\n",
+      "  \"formula\": \"KSbO3\",\n",
+      "  \"H_f\": \"-1.39231271975\"\n",
+      "}\n",
+      "{\n",
+      "  \"crystal system\": \"monoclinic\",\n",
+      "  \"bandgap\": \"2.2218\",\n",
+      "  \"formula\": \"Mg3(HO3)2\",\n",
+      "  \"H_f\": \"-1.8332794854309091\"\n",
+      "}\n",
+      "{\n",
+      "  \"crystal system\": \"orthorhombic\",\n",
+      "  \"bandgap\": \"0.6036000000000001\",\n",
+      "  \"formula\": \"PdS2\",\n",
+      "  \"H_f\": \"-0.7156774493750001\"\n",
+      "}\n",
+      "{\n",
+      "  \"crystal system\": \"monoclinic\",\n",
+      "  \"bandgap\": \"0.8796999999999999\",\n",
+      "  \"formula\": \"Li2Co(PO3)5\",\n",
+      "  \"H_f\": \"-2.5019288754011386\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = PifSystemReturningQuery(\n",
+    "            size=5,\n",
+    "            random_results=True,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(mp_dataset_id))]\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=[\n",
+    "                        ChemicalFieldQuery(\n",
+    "                            extract_as='formula',\n",
+    "                            filter=ChemicalFilter(\n",
+    "                                equal='?1O1'),\n",
+    "                            logic=\"MUST_NOT\"),\n",
+    "                        ChemicalFieldQuery(\n",
+    "                        extract_as='formula',\n",
+    "                            filter=ChemicalFilter(\n",
+    "                                equal='?xOy')\n",
+    "                        )]\n",
+    "                )\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\\n\".format(search_result.total_num_hits))\n",
+    "for i in range(5):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted))\n",
+    "\n",
+    "\n",
+    "    \n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=5,\n",
+    "            random_results=True,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=[Filter(equal=str(mp_dataset_id))]\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_as='formula'\n",
+    "                    ),\n",
+    "                    properties=[\n",
+    "                        PropertyQuery(\n",
+    "                            name=FieldQuery(\n",
+    "                                filter=[Filter(equal=\"Enthalpy of Formation\")]),\n",
+    "                            value=FieldQuery(\n",
+    "                                extract_as=\"H_f\",\n",
+    "                                logic=\"MUST\")\n",
+    "                        ),\n",
+    "                        PropertyQuery(\n",
+    "                            name=FieldQuery(\n",
+    "                                filter=[Filter(equal=\"Band Gap\")]),\n",
+    "                            value=FieldQuery(\n",
+    "                                filter=[Filter(min=1E-5)],\n",
+    "                                extract_as=\"bandgap\",\n",
+    "                                logic=\"MUST\")\n",
+    "                        ),\n",
+    "                         PropertyQuery(\n",
+    "                            name=FieldQuery(\n",
+    "                                filter=[Filter(equal=\"Crystal System\")]),\n",
+    "                            value=FieldQuery(\n",
+    "                                extract_as=\"crystal system\",\n",
+    "                                logic=\"SHOULD\")\n",
+    "                        )]\n",
+    "                )\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "search_result = client.search.pif_search(query)\n",
+    "print( \"{} hits\\n\".format(search_result.total_num_hits))\n",
+    "for i in range(5):\n",
+    "    print( pif.dumps(search_result.hits[i].extracted, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ExperimentalDesign-4.ipynb
+++ b/ExperimentalDesign-4.ipynb
@@ -1,0 +1,556 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "from os import environ\n",
+    "\n",
+    "from citrination_client import PifSystemQuery, PifSystemReturningQuery\n",
+    "from citrination_client import FieldQuery, ValueQuery, NameQuery\n",
+    "from citrination_client import PropertyQuery,DataQuery, DatasetQuery, ChemicalFieldQuery, Filter\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Experimental design with Citrination\n",
+    "\n",
+    "In this notebook, we demonstrate how to use Citrination to select experiments (or simulations, or literature searches) to maximize the impact on an optimization problem."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Case study: thermoelectrics\n",
+    "\n",
+    "Given a list of thermoelectric candidates, how many experiments do we need to find the best one?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Here, _best_ will be with respect to the thermoelecric figure of merit, ZT:\n",
+    "    $$ ZT = \\frac{\\sigma S^2 T}{\\lambda}, $$\n",
+    "where $\\sigma$ is the electrical conductivity, $S$ is the Seebeck coefficient, $T$ is the temperature, and $\\lambda$ is the thermal conductivity.  Higher is better."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Getting the data\n",
+    "\n",
+    "We begin by querying for the thermoelectric dataset, which is on Citrination [here](https://citrination.com/datasets/150888).  We want the formula and zT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_id = 150888\n",
+    "\n",
+    "system_query = PifSystemQuery(\n",
+    "    chemical_formula=ChemicalFieldQuery(\n",
+    "        extract_as=\"formula\"\n",
+    "    ),\n",
+    "    properties=PropertyQuery(\n",
+    "        name=FieldQuery(\n",
+    "            filter=[Filter(equal=\"ZT\")]\n",
+    "        ),\n",
+    "        value=FieldQuery(\n",
+    "            extract_as=\"ZT\"\n",
+    "        )\n",
+    "    )\n",
+    ")\n",
+    "thermoelectric_query = PifSystemReturningQuery(\n",
+    "                        random_seed=0,\n",
+    "                        query=DataQuery(\n",
+    "                            dataset=DatasetQuery(\n",
+    "                                id=[Filter(equal='150888')]\n",
+    "                            ),\n",
+    "                        system=system_query))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Let's run it and see what we get:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Citrination Client Warning - Query size greater than max system size - only 10000 results will be returned\n",
+      "We found 165 records\n",
+      "[{'formula': 'La0.98Sr0.02CoO3', 'ZT': '0.026234732'}, {'formula': 'Zr0.4Hf0.4Ti0.2NiSn', 'ZT': '0.030958179'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "search_result = client.search.pif_search(thermoelectric_query)\n",
+    "print(\"We found {} records\".format(search_result.total_num_hits))\n",
+    "print([x.extracted for x in search_result.hits[0:2]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "This dataset has all the ZT values already, so we want to drop most of them before trying to design an experiment:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from random import shuffle, seed\n",
+    "seed(1)\n",
+    "full_data = [x.extracted.copy() for x in search_result.hits]\n",
+    "shuffle(full_data)\n",
+    "known_subset = full_data[:20]\n",
+    "unknown_subset = full_data[20:]\n",
+    "for x in unknown_subset: \n",
+    "    del x['ZT']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Our goal is to pick the best material to measure next from `unknown_subset`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Training a model on known data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "We train a model using the csv -> dataset -> data_view workflow described in the [modeling tutorial](https://github.com/CitrineInformatics/learn-citrination/blob/master/MLonCitrination.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Create a csv\n",
+    "\n",
+    "The csv needs headers that conform to our [CSV template](http://help.citrination.com/knowledgebase/articles/1188136-citrine-template-csv-csv)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def write_csv(name, rows):\n",
+    "    with open(name, \"w\") as f:\n",
+    "        f.write(\"FORMULA, PROPERTY: ZT \\n\")\n",
+    "        for row in rows:\n",
+    "            f.write(\"{formula:s}, {ZT:s}\\n\".format(**row))\n",
+    "write_csv('known_thermoelectrics.csv', known_subset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "The rest of the model building process is on the website:\n",
+    " 1. Go to the [Add Datasets](https://citrination.com/add_data) page and upload `known_thermoelectrics.csv` using the `Citrine: Template CSV` ingester from the drop down menu.\n",
+    " 1. Go to the [data views page](https://citrination.com/data_views) and click \"Create new data view\"\n",
+    " 1. Search for the property name \"ZT\" and select the dataset you created before.  Advance with the \"NEXT >\" button in the top right corner\n",
+    " 1. Follow the guide to create a data view that has `formula` as an input and `ZT` as an output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Apply the model to unknown data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "First, we'll use the trained model to make predictions via the API.  Change the `view_id` below to point to your view."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TiO2\n",
+      "We predict the ZT of TiO2 (@ 300K) to be <citrination_client.models.predicted_value.PredictedValue object at 0x10883c390> +/- <citrination_client.models.predicted_value.PredictedValue object at 0x10883c390>\n"
+     ]
+    }
+   ],
+   "source": [
+    "view_id = \"3904\"\n",
+    "\n",
+    "inputs = [{\"formula\": \"TiO2\"}]\n",
+    "prediction = client.models.predict(view_id, inputs, method=\"scalar\")\n",
+    "\n",
+    "print(inputs[0]['formula'])\n",
+    "print(\"We predict the ZT of {} (@ 300K) to be {} +/- {}\".format(inputs[0]['formula'], prediction[0].get_value('Property ZT'), prediction[0].get_value('Property ZT')))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Maximum likelihood of improvement\n",
+    "\n",
+    "This tutorial is about _experimental design_, so we need to pick a criterion for experimental selection.\n",
+    "\n",
+    "There are many, but a straight forward and powerful one is \"maximum likelihood of improvement\", which is easy to compute if we assume the output distribution is normal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from scipy.special import erf\n",
+    "from math import sqrt\n",
+    "\n",
+    "def probability_improvement(mean, sigma, baseline):\n",
+    "    return float(0.5 * (1.0 + erf((mean - baseline) / (sigma * sqrt(2.0)))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "What is the baseline?  The largest value in the known data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The highest ZT value in the known subset is 0.424000225\n"
+     ]
+    }
+   ],
+   "source": [
+    "baseline_ZT = max(float(x['ZT']) for x in known_subset)\n",
+    "print(\"The highest ZT value in the known subset is {}\".format(baseline_ZT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Now let's screen the unknown materials for likelihood of improvement:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "predictions = client.models.predict(view_id, unknown_subset)\n",
+    "for p in predictions:\n",
+    "    p_value = p.get_value('Property ZT')\n",
+    "    p.add_value('LI', probability_improvement(float(p_value.value), float(p_value.loss), baseline_ZT))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Pandas can help us look at the result.  The top values for \"LI\" are the ones we should try next."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "            formula                                 Property ZT        LI\n",
+      "0             WO2.9  [0.15556628550000007, 0.11014407093559876]  0.007402\n",
+      "1         CeFe4Sb12  [0.20955596754687503, 0.10286526296804725]  0.018548\n",
+      "2           WO2.722  [0.15561337937500003, 0.10955761375265435]  0.007148\n",
+      "3     In0.25Co4Sb12    [0.29919832456250023, 0.125702231635684]  0.160395\n",
+      "4       LaFe3CoSb12          [0.195377252, 0.09730643457811816]  0.009399\n",
+      "5      In0.3Co4Sb12    [0.29919832456250023, 0.125702231635684]  0.160395\n",
+      "6      In0.1Co4Sb12      [0.2129342765625, 0.07349687579251576]  0.002041\n",
+      "7  CeFe3.5Co0.5Sb12  [0.20955596754687503, 0.10286526296804725]  0.018548\n",
+      "8       CeFe3CoSb12  [0.20955596754687503, 0.10286526296804725]  0.018548\n",
+      "9      In0.2Co4Sb12    [0.29919832456250023, 0.125702231635684]  0.160395\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>formula</th>\n",
+       "      <th>Property ZT</th>\n",
+       "      <th>LI</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>In0.25Co4Sb12</td>\n",
+       "      <td>0.30 +/-  0.13</td>\n",
+       "      <td>0.160</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>In0.3Co4Sb12</td>\n",
+       "      <td>0.30 +/-  0.13</td>\n",
+       "      <td>0.160</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>In0.2Co4Sb12</td>\n",
+       "      <td>0.30 +/-  0.13</td>\n",
+       "      <td>0.160</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>CeFe4Sb12</td>\n",
+       "      <td>0.21 +/-  0.10</td>\n",
+       "      <td>0.019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>CeFe3.5Co0.5Sb12</td>\n",
+       "      <td>0.21 +/-  0.10</td>\n",
+       "      <td>0.019</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            formula      Property ZT     LI\n",
+       "3     In0.25Co4Sb12   0.30 +/-  0.13  0.160\n",
+       "5      In0.3Co4Sb12   0.30 +/-  0.13  0.160\n",
+       "9      In0.2Co4Sb12   0.30 +/-  0.13  0.160\n",
+       "1         CeFe4Sb12   0.21 +/-  0.10  0.019\n",
+       "7  CeFe3.5Co0.5Sb12   0.21 +/-  0.10  0.019"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "top_predictions = []\n",
+    "for p in predictions:\n",
+    "    li, form, zt = p.get_value('LI'), p.get_value('formula'), p.get_value('Property ZT')\n",
+    "    if li > 1e-03:\n",
+    "        top_predictions.append((form.value, [zt.value, zt.loss], li))\n",
+    "        \n",
+    "df = pd.DataFrame(top_predictions, columns=['formula', 'Property ZT', 'LI'])\n",
+    "print(df)\n",
+    "df['Property ZT'] = df['Property ZT'].map(lambda x: \"{:5.2f} +/- {:5.2f}\".format(*x))\n",
+    "df['LI'] = df['LI'].map(lambda x: \"{:5.3f}\".format(x))\n",
+    "\n",
+    "df.sort_values('LI', axis=0, ascending=False)[0:5]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "These materials have a likelihood of improvement below 50%, i.e. their expected ZT value is below the highest value in the dataset.  Therefore, they are biased towards materials with high model uncertainty as well."
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ImportInstron-4.ipynb
+++ b/ImportInstron-4.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Data format to PIF converter\n",
+    "Let's write an converter to map the Instron output file to a PIF file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MTS793|MPT|ENU|1|2|.|/|:|1|0|0|A\n",
+      "\n",
+      "\n",
+      "\n",
+      "Data Acquisition\t\t\t\t\t\tTime:\t102.54224\tSec\t7/5/2010 1:24:13 PM\n",
+      "\n",
+      "Axial Displacement\tAxial Force\tAxial Strain\tTime\n",
+      "\n",
+      "mm\tN\tmm/mm\tSec\n",
+      "\n",
+      "0.001254817\t-1.2510437\t-0.18667668\t0.13891602\n",
+      "\n",
+      "0.00041648507\t-2.2480204\t-0.18673906\t0.23901367\n",
+      "\n",
+      "-0.00032296643\t-3.24281\t-0.18673992\t0.33911133\n",
+      "\n",
+      "-4.4806453e-05\t-3.5292149\t-0.18668246\t0.43920898\n",
+      "\n",
+      "-0.00031411514\t-2.728333\t-0.18660255\t0.53930664\n",
+      "\n",
+      "-0.00014413759\t-1.8402346\t-0.18657748\t0.6394043\n",
+      "\n",
+      "0.0011240146\t-1.2426991\t-0.18662354\t0.73950195\n",
+      "\n",
+      "0.0007610707\t-1.3819313\t-0.18669833\t0.83959961\n",
+      "\n",
+      "0.0004964745\t-2.4153166\t-0.18674521\t0.93969727\n",
+      "\n",
+      "0.00013828411\t-3.4589834\t-0.18672836\t1.0397949\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(\"example_data/RT-loadtofail_10e-3.txt\") as f:\n",
+    "    lines = f.readlines()\n",
+    "    print('\\n'.join(lines[:15]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "Using a given analysis script to compile the force, displacement, stress, and strain, and using those values to calculate the elastic modulus and critical stress (thanks Saurabh!), we can package the Instron output into the PIF format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from thermo_mechanical_analysis import Thermo\n",
+    "from pypif import pif\n",
+    "from pypif.obj import *\n",
+    "\n",
+    "def instron_to_pif(instron_file, material_name):\n",
+    "    instron = Thermo(instron_file)\n",
+    "    instron.extract_data()\n",
+    "    instron.calc_elastic_modulus()\n",
+    "    system = ChemicalSystem(name=material_name)\n",
+    "\n",
+    "    elastic_modulus = Property(name=\"Elastic Modulus\", units=\"MPa\", scalars=instron.elastic_modulus)\n",
+    "    critical_stress = Property(name=\"Critical Stress\", units=\"MPa\", scalars=instron.critical_stress)\n",
+    "    stress_strain = Property(name=\"Stress\", units=\"MPa\", scalars=instron.stress,\n",
+    "                             conditions=Value(name=\"Strain\", units=\"mm/mm\", scalars=instron.strain))\n",
+    "    force_displacement = Property(name=\"Force\", units=\"N\", scalars=instron.force,\n",
+    "                                  conditions=Value(name=\"Displacement\", units=\"mm\", scalars=instron.displacement))\n",
+    "    system.properties = [elastic_modulus, critical_stress, stress_strain, force_displacement]\n",
+    "    return system"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "Now, upload the result to Citrination."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "from os import environ\n",
+    "\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " You can use your previously created tutorial dataset_id or create a new one in the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "160724\n"
+     ]
+    }
+   ],
+   "source": [
+    "#comment this cell if you have an ID from a dataset you created previously\n",
+    "\n",
+    "import random\n",
+    "import string\n",
+    "import json\n",
+    "\n",
+    "random_string = ''.join([random.choice(string.ascii_uppercase + string.digits) for i in range(5)])\n",
+    "dataset_name = \"Tutorial dataset \" + random_string\n",
+    "\n",
+    "dataset = client.data.create_dataset(name=dataset_name, description=\"Dataset for tutorial\", public=False)\n",
+    "\n",
+    "dataset_id = dataset._id\n",
+    "print(dataset_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Elastic Modulus:78286.46438101279\n",
+      "Critical Stress:677.7138222\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<citrination_client.data.upload_result.UploadResult at 0x10aa5d6a0>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "from os import environ\n",
+    "\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')\n",
+    "\n",
+    "instron = instron_to_pif(\"example_data/RT-loadtofail_10e-3.txt\", \"Sample\")\n",
+    "instron.uid = \"instron_example\"\n",
+    "\n",
+    "with open(\"example_data/instron.json\", 'w') as fp:\n",
+    "    pif.dump(instron, fp)\n",
+    "    \n",
+    "client.data.upload(dataset_id, \"example_data/instron.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ImportVASP-4.ipynb
+++ b/ImportVASP-4.ipynb
@@ -1,0 +1,401 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbpresent": {
+     "id": "f2f733dc-95c8-4751-a337-7bba7fcbe4d7"
+    },
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Importing data from VASP calculations into Citrination\n",
+    "\n",
+    "Citrination is a public, un-siloed repository of materials data coupled to analysis and modeling tools.\n",
+    "\n",
+    "By putting data on Citrination, you can:\n",
+    " 1. Share incremental results within your group\n",
+    " 1. Supplement your data with similar published data\n",
+    " 1. Release your data to the public as you publish associated papers\n",
+    " 1. Recieve feedback on the quality of your DFT calculations\n",
+    " 1. View statistical analyses of the data as it comes in\n",
+    " 1. Build machine learning models on the data that update as data comes in"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "There are two steps for getting data from any format onto Citrination:\n",
+    " 1. formatting the data as a PIF\n",
+    " 1. uploading to Citrination"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbpresent": {
+     "id": "c41a4f53-9a6a-435e-b554-90780aa20fcd"
+    },
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Formatting VASP outputs as PIFs\n",
+    "\n",
+    "We provide scripts to extract common conditions and properties from VASP calculations.  You just pass in a path to the calculation and it returns a PIF!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "nbpresent": {
+     "id": "802a8008-2cc3-4892-8bb9-3ddc26885a40"
+    },
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dfttopif import directory_to_pif\n",
+    "from os import chdir\n",
+    "\n",
+    "chdir(\"./example_data\")\n",
+    "rundir = \"./Al.cF4\"\n",
+    "pif = directory_to_pif(rundir, quality_report=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbpresent": {
+     "id": "38c67c58-1de7-47f1-a50a-25cc55fe7729"
+    },
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "The PIF is a lightweight schema on top of the JSON format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "nbpresent": {
+     "id": "b49a5a35-061c-44fa-9a7f-275007109106"
+    },
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"properties\": [\n",
+      "    {\n",
+      "      \"name\": \"Converged\",\n",
+      "      \"scalars\": [\n",
+      "        {\n",
+      "          \"value\": true\n",
+      "        }\n",
+      "      ],\n",
+      "      \"conditions\": [\n",
+      "        {\n",
+      "          \"name\": \"XC Functional\",\n",
+      "        \n"
+     ]
+    }
+   ],
+   "source": [
+    "from pypif.pif import dumps\n",
+    "\n",
+    "print(dumps(pif, indent=2)[:200])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "We'll dig into PIFs more later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Uploading files to Citrination\n",
+    "\n",
+    "PIFs and other files can be uploaded to Citrination via the `citrination_client` package."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Setting up the client\n",
+    "\n",
+    "The client authenticates with your API key, which is located on the \"Account\" page on Citrination.  Please keep these keys out of your source code.  Placing them in and referencing them from environment variables is a best practice. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "from os import environ\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "We'll use the same client to query and download from Citrination later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Creating a dataset\n",
+    "\n",
+    "To upload data, we'll need to specify a dataset for it to live in. You'll only need to do this once. There are 2 ways to proceed.\n",
+    "\n",
+    "First: this notebook uses the `citrination_client` to create a dataset for you to use in this and other tutorials. \n",
+    "\n",
+    "Second: you can create a dataset on the website using the directions below. You can also share datasets via the groups tab.\n",
+    "\n",
+    "1. login to citrination.com\n",
+    "2. navigate to `Add Data`\n",
+    "3. Enter a name (ex: \"tutorial dataset\")\n",
+    "4. select `dummy_csv.csv` from the `example_data` folder and upload\n",
+    "5. if successful, the page should automatically reload with your dataset_id in the url:\n",
+    "     * https://citrination.com/datasets/**dataset_id**/show_files\n",
+    "6. comment the cell below and set `dataset_id` to the dataset_id found in step 5 above.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "160726\n"
+     ]
+    }
+   ],
+   "source": [
+    "#comment this cell if you have an ID from a dataset you created via the website\n",
+    "\n",
+    "import random\n",
+    "import string\n",
+    "import json\n",
+    "\n",
+    "random_string = ''.join([random.choice(string.ascii_uppercase + string.digits) for i in range(5)])\n",
+    "dataset_name = \"Tutorial dataset \" + random_string\n",
+    "\n",
+    "dataset = client.data.create_dataset(name=dataset_name, description=\"Dataset for tutorial\", public=False)\n",
+    "\n",
+    "dataset_id = dataset._id\n",
+    "print(dataset_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Uploading a pif to a dataset\n",
+    "\n",
+    "The client uploads files, so we write the file to `pif.json`.\n",
+    "\n",
+    "We may also want to add a tag to the pif, which will make it easier to search and filter pifs later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<citrination_client.data.upload_result.UploadResult at 0x1023485f8>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pypif.pif import dump\n",
+    "from os.path import join\n",
+    "\n",
+    "pif.tags = [\"my_first_upload\",]\n",
+    "with open(join(rundir, \"pif.json\"), \"w\") as fp:\n",
+    "    dump(pif, fp)\n",
+    "client.data.upload(dataset_id, rundir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Hands-on: upload your DFT calculations\n",
+    "\n",
+    " * If you have your own DFT calculations, try formatting and uploading them\n",
+    " * If you don't, you can use the Al-Cu data in `example_directory`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  },
+  "nbpresent": {
+   "slides": {
+    "5c8082ad-f7f3-497a-91a5-b82f1bfa6d0e": {
+     "id": "5c8082ad-f7f3-497a-91a5-b82f1bfa6d0e",
+     "layout": "grid",
+     "prev": null,
+     "regions": {
+      "3fdabdaa-d1a7-4289-8161-39096a883c62": {
+       "attrs": {
+        "height": 1,
+        "pad": 0.01,
+        "treemap:weight": 1,
+        "width": 1,
+        "x": 0,
+        "y": 0
+       },
+       "content": {
+        "cell": "f2f733dc-95c8-4751-a337-7bba7fcbe4d7",
+        "part": "whole"
+       },
+       "id": "3fdabdaa-d1a7-4289-8161-39096a883c62"
+      }
+     }
+    },
+    "8e99069f-4d09-4e7b-8dbb-b8cf82a67ae2": {
+     "id": "8e99069f-4d09-4e7b-8dbb-b8cf82a67ae2",
+     "prev": "5c8082ad-f7f3-497a-91a5-b82f1bfa6d0e",
+     "regions": {
+      "1dabf2fc-3b38-4a0d-a95c-c4574fd5354f": {
+       "attrs": {
+        "height": 0.6,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "c41a4f53-9a6a-435e-b554-90780aa20fcd",
+        "part": "whole"
+       },
+       "id": "1dabf2fc-3b38-4a0d-a95c-c4574fd5354f"
+      },
+      "ab4f31d7-8029-4c39-854f-edaad678b711": {
+       "attrs": {
+        "height": 0.2,
+        "width": 0.4,
+        "x": 0.5,
+        "y": 0.7
+       },
+       "id": "ab4f31d7-8029-4c39-854f-edaad678b711"
+      },
+      "b3bd2bc4-2c69-4998-8fe0-a09a6c579492": {
+       "attrs": {
+        "height": 0.2,
+        "width": 0.4,
+        "x": 0.1,
+        "y": 0.7
+       },
+       "id": "b3bd2bc4-2c69-4998-8fe0-a09a6c579492"
+      }
+     }
+    }
+   },
+   "themes": {}
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/IntroQueries-4.ipynb
+++ b/IntroQueries-4.ipynb
@@ -1,0 +1,920 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "from os import environ\n",
+    "\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Introduction to Queries\n",
+    "\n",
+    "Queries allow you to search and download PIFs from Citrination.  By basing scripts on queries intead of local files, you can:\n",
+    " 1. Share data with your group without running internal infrastructure or worrying about portability\n",
+    " 1. Expand your queries to include data uploaded by other groups in your field\n",
+    " 1. Publish post-processing scripts backed by Citrination data to improve reproducibility"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Query interfaces\n",
+    "\n",
+    "There are multiple interfaces to a unified backend based on elastic search:\n",
+    " 1. The website\n",
+    " 1. The python and java citrination clients \n",
+    " 1. A REST API \n",
+    " \n",
+    "This tutorial will focus on the python citrination client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## `PifSystemReturningQuery`\n",
+    "\n",
+    "Each search and download request is stored in a query object: the `PifSystemReturningQuery`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A PifQuery is structured in the following hierarchical way:\n",
+    "\n",
+    "```\n",
+    "PifSystemReturningQuery(\n",
+    "            size=0,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=Filter(equal='151278')\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        filter=ChemicalFilter(\n",
+    "                            equal='C22H15NSSi')))))\n",
+    "                            ```\n",
+    "                            \n",
+    "see our API docs for more information: https://citrineinformatics.github.io/api-documentation/#tag/search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are working through the notebooks in the order they are presented on our [API Examples](https://citrination.org/learn/api-examples/) site, use the `dataset_id` from the previous Importing VASP calculations notebook in the query below. \n",
+    "\n",
+    "Otherwise, we can start with the [Bandgaps Dataset](https://citrination.com/datasets/1160/show_search), but feel free to use any public dataset.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 2 PIFs in dataset 154987\n"
+     ]
+    }
+   ],
+   "source": [
+    "from citrination_client import PifSystemReturningQuery, PifSystemQuery\n",
+    "from citrination_client import DataQuery, DatasetQuery, ChemicalFieldQuery, ChemicalFilter, Filter\n",
+    "from citrination_client import PropertyQuery, FieldQuery\n",
+    "\n",
+    "#change dataset id below\n",
+    "my_dataset_id = 154987\n",
+    "bandgaps_dataset_id = 1160\n",
+    "\n",
+    "query_dataset = PifSystemReturningQuery(size=5, \n",
+    "                                        query=DataQuery(\n",
+    "                                            dataset=DatasetQuery(\n",
+    "                                                id=Filter(equal=str(my_dataset_id))\n",
+    "                                         )))\n",
+    "query_result = client.search.pif_search(query_dataset)\n",
+    "print(\"Found {} PIFs in dataset {}\".format(query_result.total_num_hits, my_dataset_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "The result contains the matching PIFs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"tags\": [\n",
+      "    \"my_first_upload\"\n",
+      "  ],\n",
+      "  \"category\": \"system.chemical\",\n",
+      "  \"qualityReport\": {\n",
+      "    \"body\": \"\",\n",
+      "    \"name\": \"\",\n",
+      "    \"postamble\": \"nowrap Summary:       Number of tests:   6\\n                critical error:   0\\n                         error:   0\\n               serious warning:   0\\n                       warning:   2\\n                       caution:   0\\n                recommendation:   1\\n                   information:   1\\n                       comment:   0\\n                            ok:   2\\n                not applicab\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pypif.pif import dumps\n",
+    "pifs = [x.system for x in query_result.hits]\n",
+    "print(dumps(pifs[0], indent=2)[:550])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "A `simple_chemical_search` query using the citrination client can accept lists of datasets to bring in data from collaborators:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 2 PIFs in datasets 154987 and 1160\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_dataset_id = 154987; another_dataset_id = 1160\n",
+    "\n",
+    "query = client.generate_simple_chemical_query(include_datasets=[my_dataset_id, another_dataset_id], size=500)\n",
+    "retuls = client.search.pif_search(query)\n",
+    "print(\"Found {} PIFs in datasets {} and {}\".format(\n",
+    "        query_result.total_num_hits, my_dataset_id, another_dataset_id\n",
+    "    ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbpresent": {
+     "id": "f2f733dc-95c8-4751-a337-7bba7fcbe4d7"
+    },
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Advanced Queries\n",
+    "\n",
+    "Writing analysis and post-processing on top of PIFs lets us:\n",
+    " 1. Pull in data from collaborators and published sources\n",
+    " 1. Share our methodology with other researchers with data in PIFs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Let's actually do that!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Real example: phase stability diagram\n",
+    "\n",
+    "There are surely more Al-Cu binaries on Citrination.  We will:\n",
+    " 1. Find relevant data via the web interface\n",
+    " 2. Filter the data programatically with the query\n",
+    " 3. Extract the data using query extractions\n",
+    " 4. Add the data to our plot from before"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbpresent": {
+     "id": "c41a4f53-9a6a-435e-b554-90780aa20fcd"
+    },
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Search for relevant data\n",
+    "\n",
+    "The exploratory search is usually best done on the website.  Tips and tricks:\n",
+    " * \"AlxCuy\" searches for any Al-Cu binary\n",
+    " * \"energy\" searches for properties with \"energy\" in their name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Adding filters to the query\n",
+    "\n",
+    "Now that we are querying beyond just our data, we need to filter down to records that contain Al-Cu energies.\n",
+    "\n",
+    "### Filter by chemical formula\n",
+    "\n",
+    "1. You can filter over known datasets\n",
+    "2. You can filter over all public data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n"
+     ]
+    }
+   ],
+   "source": [
+    "#filtering over a known dataset by formula='CdTe'\n",
+    "\n",
+    "res = client.pif_search(PifSystemReturningQuery(\n",
+    "            size=0,\n",
+    "            query=DataQuery(\n",
+    "                dataset=DatasetQuery(\n",
+    "                    id=Filter(equal='1160')\n",
+    "                ),\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        filter=ChemicalFilter(\n",
+    "                            equal='AlxCuy'))))))\n",
+    "print(res.total_num_hits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 139 PIFs\n"
+     ]
+    }
+   ],
+   "source": [
+    "#filtering by formula='AlxCuy'\n",
+    "\n",
+    "query = PifSystemReturningQuery(\n",
+    "            size=10,\n",
+    "            query=DataQuery(\n",
+    "                simple='AlxCuy'))\n",
+    "\n",
+    "query_result = client.search.pif_search(query)\n",
+    "print(\"Found {} PIFs\".format(query_result.total_num_hits))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Filter by property\n",
+    "\n",
+    "We can do quick filtered searches with `citrination_client.simple_chemical_search`. It returns a `PifSearchResult` object as before, but with useful filter flags. See the docs for more info.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 5 PIFs\n",
+      "Found 16 PIFs\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = client.generate_simple_chemical_query(property_name='Formation Energy', chemical_formula='AlxCuy', size=500)\n",
+    "quicksearch1 = client.search.pif_search(query)\n",
+    "print(\"Found {} PIFs\".format(quicksearch1.total_num_hits))\n",
+    "\n",
+    "query = client.generate_simple_chemical_query(property_name=['Formation Energy', 'Enthalpy of Formation'], chemical_formula='AlxCuy', size=500)\n",
+    "quicksearch2 = client.search.pif_search(query)\n",
+    "print(\"Found {} PIFs\".format(quicksearch2.total_num_hits))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "nbpresent": {
+     "id": "45a1cd9a-989f-44e6-8753-79a4abcfbe28"
+    },
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"category\": \"system.chemical\",\n",
+      "  \"references\": [\n",
+      "    {\n",
+      "      \"doi\": \"10.1016/j.commatsci.2012.02.002\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"doi\": \"10.1016/j.commatsci.2012.02.005\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"uid\": \"5CA6B3488E258DB2E0A73ADDA2F97C4D\",\n",
+      "  \"properties\": [\n",
+      "    {\n",
+      "      \"name\": \"Structure designation\",\n",
+      "      \"scalars\": [\n",
+      "        {\n",
+      "          \"value\": \"CaF[2]\"\n",
+      "        }\n",
+      "      ]\n",
+      "    },\n",
+      "    {\n",
+      "      \"name\": \"Formation energy\",\n",
+      "      \"scalars\": [\n",
+      "        {\n",
+      "          \"value\": \"-0.1799\"\n",
+      "        }\n",
+      "      ],\n",
+      "      \"units\": \"eV/atom\",\n",
+      "      \"dataType\": \"COMPUTATIONAL\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"chemicalFormula\": \"CuAl2\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pypif.pif import dumps\n",
+    "print(dumps(quicksearch1.hits[1].system, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Extract data from results using the query language\n",
+    "\n",
+    "Multiple sources typically use multiple internal formats.  The query language is smart about crawling the PIFs for properties with the right names, while `pypif` is not.  Fortunately, you can use the query language to do data extraction as well!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbpresent": {
+     "id": "261197d6-24ad-4083-8df9-33ba39ff56b7"
+    },
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Using `extract_as`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 16 PIFs\n",
+      "[{'formation_enthalpy': '-0.1889', 'formula': 'Cu3Al'}, {'formation_enthalpy': '-0.1799', 'formula': 'CuAl2'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = PifSystemReturningQuery(\n",
+    "            size=500,\n",
+    "            query=DataQuery(\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_as=\"formula\",\n",
+    "                        filter=ChemicalFilter(equal='AlxCuy'),\n",
+    "                    ),\n",
+    "                    properties=PropertyQuery(\n",
+    "                        name=FieldQuery(\n",
+    "                            filter=[Filter(equal=\"Formation energy\"), Filter(equal=\"Enthalpy of Formation\")]),\n",
+    "                        value=FieldQuery(\n",
+    "                            extract_as=\"formation_enthalpy\")\n",
+    "                    )\n",
+    "                )\n",
+    "            ))\n",
+    "\n",
+    "res = client.search.pif_search(query)\n",
+    "print(\"Found {} PIFs\".format(res.total_num_hits))\n",
+    "print([x.extracted for x in res.hits][0:2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "A few notes:\n",
+    " * `extract_as` extracts the field it is on (why we need value)\n",
+    " * `extracted` is a dictionary from String keys to values; no units or uncertainty"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Real example: phase stability diagram\n",
+    "\n",
+    "Let's create an Al-Cu phase diagram and add these points."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "We'll start with some sample DFT data and create pifs out of the samples. Then, we'll add the new points found in our query above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dfttopif import directory_to_pif\n",
+    "\n",
+    "Cu_pif = directory_to_pif(\"./example_data/Cu.cF4\")\n",
+    "Al_pif = directory_to_pif(\"./example_data/Al.cF4\")\n",
+    "AlCu_pifs = [directory_to_pif(os.path.join(\"./example_data/\", x))\n",
+    "             for x in os.listdir(\"./example_data/\") if \"Al\" in x]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def enthalpy_of_formation(energy, n_Al, n_Cu, energy_Al, energy_Cu):\n",
+    "    return (energy - n_Al * energy_Al - n_Cu * energy_Cu) / (n_Al + n_Cu)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "def get_stoich(AlCu_formula):\n",
+    "    m = re.match(r\"Al([0-9]*)Cu([0-9]*)\", AlCu_formula)\n",
+    "    if m is not None:\n",
+    "        n_Al = float(m.group(1)) if len(m.group(1)) > 0 else 1\n",
+    "        n_Cu = float(m.group(2)) if len(m.group(2)) > 0 else 1\n",
+    "        return (n_Al, n_Cu)\n",
+    "    m = re.match(r\"Cu([0-9]*)Al([0-9]*)\", AlCu_formula)\n",
+    "    if m is not None:\n",
+    "        n_Cu = float(m.group(1)) if len(m.group(1)) > 0 else 1\n",
+    "        n_Al = float(m.group(2)) if len(m.group(2)) > 0 else 1\n",
+    "        return (n_Al, n_Cu)\n",
+    "    return (0, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ReadView is a dictionary-like read-only view into a PIF that indexes members by name and elevates keys up the PIF hierarchy as long as they are unambiguous. For more info see the docs.\n",
+    "\n",
+    "Here, we'll use ReadView to populate an array of `(Energy, formula)` tuples to build our phase diagram."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pypif_sdk.readview import ReadView\n",
+    "\n",
+    "energy_Al = ReadView(Al_pif)[\"Total Energy\"].scalars[0].value / 4\n",
+    "energy_Cu = ReadView(Cu_pif)[\"Total Energy\"].scalars[0].value\n",
+    "\n",
+    "points = [(0.0, 0.0), (1.0, 0.0)]\n",
+    "for pif in AlCu_pifs:\n",
+    "    rv = ReadView(pif)\n",
+    "    energy = rv[\"Total Energy\"].scalars[0].value\n",
+    "    n_Al, n_Cu = get_stoich(rv.chemical_formula)\n",
+    "    if n_Al == 0 and n_Cu == 0: continue\n",
+    "    points.append((\n",
+    "            n_Cu / (n_Cu + n_Al),\n",
+    "            enthalpy_of_formation(energy, n_Al, n_Cu, energy_Al, energy_Cu)\n",
+    "        ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Now, let's add the new points from our queries above. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "new_points = []\n",
+    "for hit in res.hits:\n",
+    "    n_Al, n_Cu = get_stoich(hit.extracted[\"formula\"])\n",
+    "    new_points.append((\n",
+    "            n_Cu / (n_Cu + n_Al),\n",
+    "            float(hit.extracted[\"formation_enthalpy\"])\n",
+    "        ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0,0.5,'$\\\\Delta H (eV/atom)$')"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3X2YVWW9//H3Z/ABJxEUFL0kZshU8HGQOR471zE1OWX2oJWlnkmxPIcrLBvxl6ZxZRyLc8z8hVD2Mzr5yJRkdcrM9IhmamI5yIBKGGaAGCqhcDwiBsz398daA3vGGWfvmVl779n787quufZe91pr7+9eDPs798O6b0UEZmZmWaopdQBmZlb5nGzMzCxzTjZmZpY5JxszM8uck42ZmWXOycbMzDLnZGNmZplzsjEzs8w52ZiZWeZ2KXUApTJq1Kior68vdRhmZoPK4sWL/xoR+xZ6XtUmm/r6elpbW0sdhpnZoCJpdV/OczOamZllzsnGzMwy52RjZmaZq9o+GzOrDFu3bmXt2rVs2bKl1KFUlKFDhzJmzBh23XXXAXk9JxszG9TWrl3LsGHDqK+vR1Kpw6kIEcGGDRtYu3Yt48aNG5DXdDOamQ1qW7ZsYeTIkU40A0gSI0eOHNDaopONmQ16TjQDb6CvqZONmZllzsnGzCwD9fX1/PWvfwVgzz337NNrPPDAAwwfPpyJEydy6KGH8u53v5s777xzx/6ZM2dy4IEH0tDQwPjx45k2bRrt7e0DEv9Ac7IxMytjxx9/PEuWLOHpp59m7ty5fO5zn+O+++7bsX/69Om0tbWxfPlynnjiCX7zm9+UMNqeOdmYWVVpaYH6eqipSR5bWvr/mqeffjqTJk3i8MMPZ968eT0eFxFccsklHHHEERx55JEsWLAAgHPPPZef/exnO45ramri5z//+ZvOb2ho4IorruDb3/72m/b97W9/Y8uWLey99979/0AZcLIxs6rR0gJTp8Lq1RCRPE6d2v+Ec8MNN7B48WJaW1uZO3cuGzZs6Pa4n/70p7S1tbF06VIWLlzIJZdcwrp16zj//PO56aabANi0aROPPPIIH/jAB7p9jWOOOYYVK1bs2J49ezYNDQ0ccMABHHLIITQ0NPTvw2TEycbMqsaMGbB5c+eyzZuT8v6YO3cuRx99NMcddxzPPfccK1eu7Pa4hx9+mLPPPpshQ4YwevRoTjjhBB577DFOOOEEVq5cyfr16/nhD3/Ixz72MXbZpfvbICOi03ZHM9pLL73Ea6+9xm233da/D5MRJxszqxpr1hRWno8HHniAhQsXsmjRIpYuXcrEiRP7dH/Kueeey/z587nxxhv59Kc/3eNxS5YsYcKECW8q33XXXTnllFN48MEHC37vYnCyMbOqMXZsYeX52LRpE3vvvTe1tbWsWLGCRx99tMdjjz/+eBYsWMD27dtZv349Dz74IMceeywA5513Htdeey0Ahx12WLfnL1u2jK9+9at89rOffdO+iOC3v/0tBx10UN8/TIY8XY2ZVY1Zs5I+mtymtNrapLyvTjnlFK6//nomTJjAoYceynHHHdfjsR/5yEdYtGgRRx99NJK4+uqr2X///QEYPXo0EyZM4PTTT+90zkMPPcTEiRPZvHkz++23H3PnzuXkk0/esX/27NnMnz+frVu3ctRRR3HBBRf0/cNkKSLK4gc4BXgaeAa4rJv9uwML0v2/A+pz9l2elj8NvC+/95sUdXUR8+eHmQ1iy5cvL+j4+fMj6uoipCir74DXXnst3vGOd8TGjRtLHcoOude247rBpIg+fMeXRTOapCHAdcD7gcOAsyV1rUeeD7wSEe8EZgNfT889DDgLOJwkYX0nfb1eDdRIFDMbPJqaYNUqaG9PHpuaSh0RLFy4kAkTJnDhhRcyfPjwUofzJrmj+PqqLJINcCzwTEQ8GxF/A24DTutyzGnAzenzHwMnK5m85zTgtoh4IyL+TFLDOTbfNx6IkShmZv0xefJkVq9ezUUXXVTqULrV3Si+QpVLsjkQeC5ne21a1u0xEbEN2ASMzPNcACRNldQqqRXW7yjvz0gUM7NKNxDfkeWSbIoiIuZFRGNENMK+O8r7MxLFzKzSDcR3ZLkkm+eBt+dsj0nLuj1G0i7AcGBDnuf2qL8jUczMKt2sWcl3ZX+US7J5DDhY0jhJu5F0+N/R5Zg7gCnp8zOA+yMi0vKzJO0uaRxwMPD7fN60rg7mzSuPDkIzs3LV1JR8V9bV9f01yiLZpH0wnwPuAf4A/CginpJ0paQPp4d9Hxgp6RngYuCy9NyngB8By4G7gc9GxPbe3nPSpPIZiWJmleX666/nlltuAeCmm27iL3/5S4/HXnHFFSxcuLBP79PW1sZdd921Y/uOO+7gqquu6tNr9aZjFB8sXtyX8xVd5tmpFo2NjdHa2lrqMMysn/7whz90O31LjyIgdxXKrtsD7MQTT+Saa66hsbHxTfu2b9/OkCF53anRrZtuuonW1tZuZ4EeCN1dW0mLk37vwngGATOrHjNnwsaNMHt2kmAiYPp0GDEi2ddHt9xyC9dccw2SOOqoozjooIPYc889qa+vp7W1laamJvbYYw8WLVrEhAkTOPPMM7n33nu59NJLufvuu/ngBz/IGWecQX19PVOmTOEXv/gFW7du5fbbb2f8+PH8/ve/p7m5mS1btrDHHntw4403Mm7cOK644gpef/11Hn74YS6//HJef/31Hcln1apVfPrTn+avf/0r++67LzfeeCNjx47lvPPOY6+99qK1tZUXXniBq6++mjPOOGPALnFPyqIZzcwscxFJopkzJ0kwHYlmzpykvI+tPE899RRf+9rXuP/++1m6dClz5szZse+MM86gsbGRlpYW2tra2GOPPQAYOXIkjz/+OGedddabXm/UqFE8/vjjTJs2jWuuuQaA8ePH89BDD7FkyRKuvPJKvvSlL7Hbbrtx5ZVXcuaZZ9LW1saZZ57Z6XUuvPBCpkyZwrJly2hqauLzn//8jn3r1q3j4Ycf5s477+Syyy7r0+culGs2ZlYdpKRGA0mC6UgKzc07azp9cP/99/Pxj3+cUaNGAbDPPvv0ek7XxJDrox/9KACTJk3ipz/9KZBM9jllyhRWrlyJJLZu3drreyxatGjH+eeccw6XXnrpjn2nn346NTU1HHbYYbz44ou9vtZAcM3GzKpHbsLp0I9E01dve9vbety3++67AzBkyBC2bdsGwJe//GVOOukknnzySX7xi1/0aQmD7t4D3rw+TlacbMysenQ0neXqaFLro/e85z3cfvvtO1bnfPnllzvtHzZsGK+++mqfXx+Sms2BByYTo3Ss6Nnba//DP/zDjoXUWlpaOP744/sVQ3852ZhZdcjto2luTmbibG7u3IfTB4cffjgzZszghBNO4Oijj+biiy/utP+8887jM5/5DA0NDbz++ut9eo9LL72Uyy+/nIkTJ+6o7QCcdNJJLF++nIaGBhYsWNDpnG9961vceOONHHXUUdx6662d+pJKwUOfzWxQK2joc0aj0SqVhz6bmfXFzJmd76vp6MMpcp9NNXIzmplVl66JxYmmKJxszGzQq9bugCwN9DV1sjGzQW3o0KFs2LDBCWcARQQbNmxg6NChA/aa7rMxs0FtzJgxrF27lvXr1/d+sOVt6NChjBkzZsBez8nGBo8iT6Bog8Ouu+7KuHHjSh2G9cLNaDY4zJzZ+V6IjiGrHq5qNig42Vj5y2gCRTMrHjejWfnLaAJFMysezyBgg0cE1ORUxtvbnWjMiqyvMwi4Gc0GhwwmUCw3LS1QX5/k0/r6ZNusUjjZWPnLaALFctLSAlOnwurVycdZvTrZdsKxSuE+Gyt/UjJRYm4fTUcfzogRFdGUNmMGbN7cuWzz5qS8qak0MZkNJPfZ2OBRwffZ1NR0X0GTkoqcWblwn41VvgqeQHHs2MLKzQYbJxuzMjBrFtTWdi6rrU3KzSqBk41ZGWhqgnnzoK4uqbDV1SXb7q+xSuEBAmZloqnJycUql2s2ZmaWOScbMzPLnJONmZllzsnGzMwy52RjZmaZc7IxM7PMlTzZSNpH0r2SVqaPe/dw3JT0mJWSpuSUPyDpaUlt6c9+xYvezMzyUfJkA1wG3BcRBwP3pdudSNoH+Arw98CxwFe6JKWmiGhIf14qRtBmZpa/ckg2pwE3p89vBk7v5pj3AfdGxMsR8QpwL3BKkeIzM7N+KodkMzoi1qXPXwBGd3PMgcBzOdtr07ION6ZNaF+WKmh2RjOzClGU6WokLQT272bXjNyNiAhJha550BQRz0saBvwEOAe4pYc4pgJTAcZ6Ol0zs6IpSrKJiMk97ZP0oqQDImKdpAOA7vpcngdOzNkeAzyQvvbz6eOrkn5A0qfTbbKJiHnAPEjWsyn8k5iZWV+UQzPaHUDH6LIpwM+7OeYe4L2S9k4HBrwXuEfSLpJGAUjaFfgg8GQRYjYzswKUQ7K5CvgnSSuByek2khol/SdARLwMfBV4LP25Mi3bnSTpLAPaSGpA3yv+RzAzs7fiZaHNzCxvXhbazMzKlpONmZllzsnGzMwy52RjZmaZc7IxM7PMOdmYmVnmnGzMzCxzTjZmVjItLVBfDzU1yWNLS6kjsqwUZW40M7OuWlpg6lTYvDnZXr062QZoaipdXJYN12zMrCRmzNiZaDps3pyUW+VxsjGzklizprByG9wKTjaS3iZpSBbBmFn16GlJKS81VZl6TTaSaiT9s6RfSnoJWAGsk7Rc0jckvTP7MM2s0syaBbW1nctqa5Nyqzz51Gx+DRwEXA7sHxFvj4j9gH8EHgW+LumTGcZoZhWoqQnmzYO6OpCSx3nzPDigUvW6xICkXSNia3+PKTdeYsDMrHCZLTGQm0TS1TDf8hgzM7Ou8r7PJl018wOStgF/AZYByyLiW1kFZ2ZmlaGQmzqPB8ZExHZJBwJHA0dlE5aZmVWSQpLN74CRwEsR8TzwPHBXJlGZmVlFKeQ+m+8Cv5H0BUnHSxqeVVBmZlZZCkk284FbSGpDFwCPSPpTJlGZmVlFKaQZbW1E/EdugaTdBzgeMzOrQIXUbNokNecWRMQbAxyPmZlVoEJqNqOByZK+CDwOLAXaIuL2TCIzM7OKkXeyiYhPwI6ms8OBI4G/B5xszMzsLRVyU+c+wHRgP2A5cEtE3JxVYDZIRCQTW/W0bWZGYX02twGvAr8AaoGHJR2bSVQ2OMycCdOnJwkGksfp05NyM7MchSSbfSPi6oi4Mx2V9iFgbkZxWbmLgI0bYc6cnQln+vRke+PGnQnIzIzCBgi8LOnIiHgCICKelVTb20lWoSSYPTt5PmdO8gPQ3JyUuynNzHL0usTAjgOl8cCPgYeAJ4DDgAMj4iPZhZcdLzEwQCKgJqeC3N7uRGNWwTJbYiDHFuAYksXU9iMZ+nx2oW9oFaSj6SxXbh+OmVmqkGTz04j4W0T8KCJmRsT3gIb+BiBpH0n3SlqZPu7dw3F3S9oo6c4u5eMk/U7SM5IWSNqtvzFZHnL7aJqbkxpNc3PnPhwzs1SvyUbSJyRdBQyTNEFS7jnzBiCGy4D7IuJg4L50uzvfAM7ppvzrwOyIeCfwCnD+AMRkvZFgxIjOfTSzZyfbI0a4Kc3MOslnWegDgZOBbwKPAYcCG0kWUNs3Iv6+XwFITwMnRsQ6SQcAD0TEoT0ceyLwhYj4YLotYD2wf0Rsk/QuYGZEvK+393WfzQDxfTZmVaWvfTa9jkZL1665RdKfIuK36ZuNBOqBFYW+YTdGR8S69PkLJNPi5GsksDEitqXba4EDByAmy1fXxOJEY2bdKGTo8wpJ00gGCjwFPBERr+dzoqSFwP7d7JqRuxERISmzxn5JU4GpAGPHjs3qbczMrItCks1/AQuBacAfgXdJejYixvd2YkRM7mmfpBclHZDTjPZSATFtAEZI2iWt3YwhWUG0pzjmkfYzNTY2ugfbzKxIChmNNiwirgRejIgTSIY9/2gAYrgDmJI+nwL8PN8TI+lw+jVwRl/ONzOz4ij0PhuANyTtERE/Ad47ADFcBfyTpJXA5HQbSY2S/rPjIEkPkcwwfbKktZI6BgF8EbhY0jMkfTjfH4CYzMxsABXSjHZNOvPzAuAGSY8AI/obQERsIBnt1rW8FfiXnO3jezj/WcATgpqZlbF87rN5lyRFxE8i4uWI+CbwK+DtwEczj9DMzAa9fGo25wLXSfojcDdwd0Tckm1YZmZWSfK5z2Ya7JiI8/3ATZKGk3TM3w38NiK2ZxqlmZkNavk0o00AiIgVETE7Ik4B3gM8DHwc+F22IZqZ2WCXTzPaLyX9BrgiIp4DSG/mvCv9MTMze0v5DH0eDzwOPChpjqR9M47JzMwqTK/JJl1W4FvABOA54PeSvippr8yjMzPro5YWqK9P1varr0+2rXTyvqkzIrZExDXAEcDrwGJJX8gsMjOzPmppgalTYfXqZCLy1auTbSec0sk72Uiql3QKyY2WY4FXgX/PKjAzs76aMQM2b+5ctnlzUm6l0esAAUnLSKbtX0OypMAfSBY5+zbJhJxmZmVlzZrCyi17+YxGOx34c/S2ypqZWZkYOzZpOuuu3EojnwECz6brzBws6fuSvl2MwMzM+mrWLKit7VxWW5uUW2kUMuvzrcCPgXcDSDpCkqetMbOy09QE8+ZBXV2yeGxdXbLd1FTqyKpXIbM+10TEryT9O0BEPCnpiIziMjPrl6YmJ5dyUkjN5i+SxgEBIEnAHplEZWY22HTt1nY3dyeFJJuLgO8B+0v6FHAb8GQmUZmZDSYzZ8L06TsTTESyPXNmKaMqK4Xc1LkKOAX4PPAO4DfAOdmEZWY2SETAxo0wZ87OhDN9erK9caNrOKl87rNRx7DniNhGMkjgxz0dY2ZWVSSYPTt5PmdO8gPQ3JyUS6WLrYzkU7P5taQLJXUaoS5pN0nvkXQzMCWb8MzMBoHchNPBiaaTfJLNKcB24IeS/iJpuaQ/AyuBs4FrI+KmDGM0MytvHU1nuXL7cCyvlTq3AN8BviNpV2AU8HpEbMw6ODOzspfbR9PRdNaxDa7hpPLpszkU+GMktgLrsg/LrApFdP5S6rpt5UmCESM699F0NKmNGOF/w5R669eX9ARQRzLp5jLgiY7HiHgp8wgz0tjYGK2traUOwywxc2Yycqnjy6rjr+URIzx8drCokj8WJC2OiMZCz8tnbrQjgX2BacCHSIY9fwlYJumFQt/QzLrw0NnK0DWxVGCi6Y+8pquJiDeAxyT9b0Rc2FEuae/MIjOrFh46a1WgkBkEIJ2qZsdGxCsDGItZ9fLQWatwvSYbSddJOl/SRMC/+WZZ8NBZq3D51GyWAg3AtcCw9D6b2yX9m6Qzsw3PrAp0HTrb3p485vbhmA1y+dxnMy93W9IY4ChgEnAusCCb0MyqhIfOWhXodehzp4OTprSzgbNI7rcZHxHDM4otUx76bGWnSobO2uDW16HP+dzUeQhJgvln4H+BHwEnRMSf02lrzGwgeOisVbB8hj6vAB4DzoiIJ7rsc2OymZn1Kp8BAh8F/gz8t6RbJX0onSNtQEjaR9K9klamj93euyPpbkkbJd3ZpfwmSX+W1Jb+NAxUbGZmNjDymUHgZxFxFvBO4FfAVGCtpBuBvQYghsuA+yLiYOC+dLs736DnxdouiYiG9KdtAGIyM7MBVMhKna9FxA8i4kPAeGARyRxp/XUacHP6/Gbg9B7e/z7g1QF4PzMzK7JCZxAAkpkDImJeRLxnAGIYHREdM0m/AIzuw2vMkrRM0mxJu/d0kKSpklolta5fv75PwZqZWeH6lGwKJWmhpCe7+Tkt97h0aelCBx1cTlLT+jtgH+CLPR2YJsjGiGjcd999C/0YVmpdh+n7ZseiaWmB+nqoqUkeW1pKHZENNnlNxNlfETG5p32SXpR0QESsk3QAUNCyBTm1ojfSfqQv9CNUK1eegr9kWlpg6lTYvDnZXr062QZoaipdXDa4FKVm04s7gCnp8ynAzws5OU1QSBJJf8+TAxqdlV4xpuB3ralHM2bsTDQdNm9Oys3yVdAMApkEII0kuVF0LLAa+EREvCypEfhMRPxLetxDJM1lewIbgPMj4h5J95OstyOgLT3nf3t7X88gMMjkJpgOAzUFv2tNb6mmpvvcKyXTuFl1yWzxtKxFxIaIODkiDo6IyRHxclre2pFo0u3jI2LfiNgjIsZExD1p+Xsi4siIOCIiPplPorFBSOKCNzpPwX/BGwOQaLxwWa/Gji2s3Kw7JU82Zvm4YFpwyPWdp+A/5PrpXDCtn8kgnfRyxfvSWZZramDOnGS7SteT6ToY4NRToba28zG1tTBrVimis8HKycbKXwSHfnc6FzGHa2lGtHMtzVzEHA79bv+n4G/5gZj0YOda06QHZ9Pyg+pMNFOnJoMAIpLHm2+GKVOgri7JvXV1MG+eBwdYYYoyGs2sXyReiRFcSzPTmQ0ofYSN0f8p+Gd8KZj1euda06zXpzPjS7NpaqquhNPTYIC77oJVq0oSUt95Fu2yUvIBAqXiAQKDyy67wPbtQefFYoMhQ8S2bf144Qjm1EynOa01TWc2s0lqUXNoprm9uprSKmYwgAd9ZGbQDhAwy0dyX0fXL33tuN+jzyRi+JtrTdfSTAyvvoXLKmIwgAd9lKeIqMqfSZMmhQ0u06ZFDBkSAcnjtGkD87rz50fU7tEeybdQ8lO7R3vMnz8wrz+YzJ8fUVsbna9FbQy+a9HeHtHc3PmDNDcn5dYvQGv04TvXzWhmJB3jM2bAmjXJX/GzZlVvB3jFXIuIpF2wQ3t71dVUs9DXZjQnGzOrPBGseP90xt+z8ybgFe9rZvyvqqsPLgvuszEzg06JJneo/Ph75rDi/f0fKm9946HPZlZZJO5+dAR3dzNUnkdHMN41m5JwM5qZVZxkCPebh8pLGlxDuMuQm9HMzFLJUO03D5UfVEO4K4yTjQ0eXgbA8jRrludzKzdONjY4zJy58wY92Hmjnu8Gt240NSXzt3k+t/LhZGPlL+eO8BuGT6dGwQ3DfUe4vbWmpmQ+t/b25NGJprQ8Gs3Kn0RL42w2Dgk+++ocPs0ceBWuG/J5RjTOpsmji6w7noizrLhmY4PC+s/9G1u3dy7buj0pN3sTN7uWHScbK38RaNMrXMTcTsUXMRdtesXNaNaZJ+IsS25Gs0Fh2DDg1R7KzXKlq68CSYKZk05Z01y9q6+WA9dsrPxJNE7em+uGfL5T8XVDPk/j5L395WFvlptwOjjRlJSTjQ0KR/3kK5x8cueyk09Oys3epKPpLNd0z4tWSk42Vv7SL47x/z03aQppb4fm5mTbXyDWVW4fTc7vS6c+HCs699lY+ZOS5Xxz29w7mkhGVN9qmtaLjt+XCy/s/PvS3u7flxJysrHBYebMzvdJdHyB+IvDuvPAA7Bp087fmQh46CEYPrzUkVUtN6PZ4NE1sTjRWHfa25NE09bGU0MnUaN2nho6CdraknJP+1wSTjZmVllqami5eDFL1cDhW9toZwiHb21jqRpouXhx56WirWi8no2ZVZz6eli9up1gyI4ysZ26uhpWrSpZWBXB69mYmaXWrG7ncSZ1KnucSaxZ7Sa0UnGyMbPK0t7OE7tOYiJtLKEBsZ0lNDCRNp7YdZL7bErEycasXHhxuIFRU8Oog4azVA0cw2KghmNI+nBGHTTcfTYl4qtuVg48S/GAGv2HB3jy5sXU1dWki6fV8OTNixn9hwdKHVrVKnmykbSPpHslrUwf9+7mmAZJiyQ9JWmZpDNz9o2T9DtJz0haIGm34n4Cs37yLMWZaDqnpvPiaeeU/OuuqpXD1b8MuC8iDgbuS7e72gycGxGHA6cA10oake77OjA7It4JvAKcX4SYzQZOxw2qHVOq1NTsnGrFN65ahSj50GdJTwMnRsQ6SQcAD0TEob2csxQ4A3gGWA/sHxHbJL0LmBkR7+vtfT302cpOROf+hPZ2JxorO4N56PPoiFiXPn8BGP1WB0s6FtgN+BMwEtgYEdvS3WuBA7MK1CwznqXYKlxRko2khZKe7ObntNzjIqlm9fi/K6353Ap8KiIKHr8oaaqkVkmt69evL/hzmGXCsxRbFSjKRJwRMbmnfZJelHRATjPaSz0ctxfwS2BGRDyaFm8ARkjaJa3djAGef4s45gHzIGlG69unMRtgntXaqkA5zPp8BzAFuCp9/HnXA9IRZv8F3BIRP+4oj4iQ9GuS/pvbejrfrOx5VmurcOXQZ3MV8E+SVgKT020kNUr6z/SYTwDvBs6T1Jb+NKT7vghcLOkZkj6c7xc3fLMB4lmtrYKVfDRaqXg0mlkZyq3ddbdtJTeYR6OZmXkWhQrnZGNmpedZFCqek41ZuajmiTilZMnmhobOsyg0NCTlbkob9JxszMpBtTchRexYyrmTjqWcqynxVignG7NScxNSUnP55jd5eWxDp+KXxzbAN7/pmk0FcLIxKzVPxAkRrDj1YvZZ07lms8+aNlacenF1JNwK52RjVg4kWhpndypqaaySRAMgcfei4Syhc81mCQ3cvch9NpXAycasDLTMDzZ+qvNEnBs/NZ2W+VXyF30E+p9NTKSNa2lGtHMtzUykDf2P+2wqgZONWalF8MYF0/nstjmdvmg/u20Ob1xQJRNxSsTwEVxLM9OZDYjpzOZamonhnh+uEpTD3Ghm1U3iuVff/EULsOnV6vmi3fe6mUz914DXOz6vmLHHbOZdVx2fv9J5uhqzMlBfD6tXB5D7xRrU1YlVq0oTUym0tMCMGbBmDYwdC7NmQVNTqaOyXJ6uxmwQmzULams7/wVfWytmzSpRQCXS1ASrViVL+qxa5URTSZxszMpAUxPMmwd1dUmrWV1dsu0vW6sU7rMxKxNNTU4uVrlcszEzs8w52ZiZWeacbMzMLHNONmZmljknGzMzy5yTjZmZZc7JxszMMudkY2ZmmXOyMTOzzDnZmJlZ5pxszMwsc042ZmaWOScbMzPLnJONmZllzsnGzMwy52RjZmaZU0SUOoaSkPQq8HSp4ygTo4C/ljqIMuFrsZOvxU6+FjsdGhHDCj2pmlfqfDoiGksdRDmQ1OprkfC12MnXYidfi50ktfblPDejmZlZ5pxszMwsc9Vus61wAAAF7ElEQVScbOaVOoAy4muxk6/FTr4WO/la7NSna1G1AwTMzKx4qrlmY2ZmRVLxyUbSKZKelvSMpMu62b+7pAXp/t9Jqi9+lNnL4zpcLGm5pGWS7pNUV4o4i6G3a5Fz3MckhaSKHYWUz7WQ9In0d+MpST8odozFksf/kbGSfi1pSfr/5NRSxFkMkm6Q9JKkJ3vYL0lz02u1TNIxvb5oRFTsDzAE+BPwDmA3YClwWJdjLgCuT5+fBSwoddwlug4nAbXp82mVeB3yvRbpccOAB4FHgcZSx13C34uDgSXA3un2fqWOu4TXYh4wLX1+GLCq1HFneD3eDRwDPNnD/lOBXwECjgN+19trVnrN5ljgmYh4NiL+BtwGnNblmNOAm9PnPwZOlqQixlgMvV6HiPh1RGxONx8FxhQ5xmLJ53cC4KvA14EtxQyuyPK5Fv8KXBcRrwBExEtFjrFY8rkWAeyVPh8O/KWI8RVVRDwIvPwWh5wG3BKJR4ERkg54q9es9GRzIPBczvbatKzbYyJiG7AJGFmU6Ionn+uQ63ySv1oqUa/XIm0SeHtE/LKYgZVAPr8XhwCHSPqtpEclnVK06Iorn2sxE/ikpLXAXcCFxQmtLBX6nVLVMwhYNyR9EmgETih1LKUgqQb4JnBeiUMpF7uQNKWdSFLbfVDSkRGxsaRRlcbZwE0R8X8lvQu4VdIREdFe6sAGg0qv2TwPvD1ne0xa1u0xknYhqR5vKEp0xZPPdUDSZGAG8OGIeKNIsRVbb9diGHAE8ICkVSTt0XdU6CCBfH4v1gJ3RMTWiPgz8EeS5FNp8rkW5wM/AoiIRcBQkjnTqlFe3ym5Kj3ZPAYcLGmcpN1IBgDc0eWYO4Ap6fMzgPsj7QGrIL1eB0kTge+SJJpKbZeHXq5FRGyKiFERUR8R9ST9Vx+OiD7NB1Xm8vn/8TOSWg2SRpE0qz1bzCCLJJ9rsQY4GUDSBJJks76oUZaPO4Bz01FpxwGbImLdW51Q0c1oEbFN0ueAe0hGm9wQEU9JuhJojYg7gO+TVIefIekQO6t0EWcjz+vwDWBP4PZ0fMSaiPhwyYLOSJ7XoirkeS3uAd4raTmwHbgkIiqt5p/vtfg/wPckTScZLHBeBf5hCoCkH5L8kTEq7aP6CrArQERcT9JndSrwDLAZ+FSvr1mh18rMzMpIpTejmZlZGXCyMTOzzDnZmJlZ5pxszMwsc042ZmaWOScbszxJ2l/SbZL+JGmxpLskHVLA+eMltaWzBh/Uz1gacmcdlvTht5rB2qzUPPTZLA/p5KyPADen9xkg6Whgr4h4KM/XuAzYJSK+1s1rq5BpTySdRzIb9efyPceslFyzMcvPScDWjkQDEBFLI+IhSSdKurOjXNK302RATtmpwEXAtHRNlPp07ZRbgCeBt0v6f5Ja03Vj/i3n3L+T9IikpZJ+L2k4cCVwZlpTOlPSeZK+nR5fL+l+7VybaGxaflO6Bskjkp6VdEZ2l8usMycbs/wcASzu68kRcRdwPTA7Ik5Kiw8GvhMRh0fEamBGRDQCRwEnSDoqnTplAdAcEUcDk4HXgCtI1hxqiIgFXd7uWyQ1sKOAFmBuzr4DgH8EPghc1dfPY1aoip6uxqzMrU7XAunwCUlTSf5fHkCyQFcA6yLiMYCI+B+AXpZcehfw0fT5rcDVOft+ljbXLZc0ekA+hVkeXLMxy89TwKQe9m2j8/+loXm+5msdTySNA74AnJzWSH5ZwOsUInc270pbJNDKmJONWX7uB3ZPax4ApM1cxwOrgcMk7S5pBOnMwAXaiyT5bEprHO9Py58GDpD0d+l7DkuXwniVZDmE7jzCzgllm4C8BjCYZcnJxiwP6ey+HwEmp0OfnwL+A3ghIp4jWefkyfRxSR9ef2l63grgB8Bv0/K/AWcC35K0FLiXpMbza5IE1ybpzC4vdyHwKUnLgHOA5kLjMRtoHvpsZmaZc83GzMwy52RjZmaZc7IxM7PMOdmYmVnmnGzMzCxzTjZmZpY5JxszM8uck42ZmWXu/wMJrhHbANuKxAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x111a5c5f8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.scatter(*zip(*points), color='blue', marker='o', label='alloyDB')\n",
+    "plt.scatter(*zip(*new_points), color='red', marker='x', label='citrination')\n",
+    "plt.legend(loc=\"best\")\n",
+    "plt.xlim(0, 1)\n",
+    "plt.xlabel(\"Cu fraction\")\n",
+    "plt.ylabel(\"$\\Delta H (eV/atom)$\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Filter by value\n",
+    "\n",
+    "A few of the values in are mislabeled: they are called \"Enthalpy of Formation\" but are actually total energies (per atom).  We can filter them out by recognizing that all the Al-Cu binaries have enthalpy of formation above $-1.0 eV / $atom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "query = PifSystemReturningQuery(\n",
+    "            size=500,\n",
+    "            query=DataQuery(\n",
+    "                system=PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_as=\"formula\",\n",
+    "                        filter=ChemicalFilter(equal='AlxCuy'),\n",
+    "                    ),\n",
+    "                    properties=PropertyQuery(\n",
+    "                        name=FieldQuery(\n",
+    "                            filter=[Filter(equal=\"Formation energy\"), Filter(equal=\"Enthalpy of Formation\")]),\n",
+    "                        value=FieldQuery(\n",
+    "                            extract_as=\"formation_enthalpy\",\n",
+    "                            filter=[Filter(min=-1.0)])\n",
+    "                    )\n",
+    "                )\n",
+    "            ))\n",
+    "\n",
+    "query_result = client.search.pif_search(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "new_points = []\n",
+    "for hit in query_result.hits:\n",
+    "    n_Al, n_Cu = get_stoich(hit.extracted[\"formula\"])\n",
+    "    new_points.append((\n",
+    "            n_Cu / (n_Cu + n_Al),\n",
+    "            float(hit.extracted[\"formation_enthalpy\"])\n",
+    "        ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "This looks much better:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0,0.5,'$\\\\Delta H (eV/atom)$')"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3X94VNW97/H3N4hiLBJURB4pCVp/IL8CyfGIPYgItdRWoVZrPalC9Rye4q8Yb632cKq0vZyjtdcQlF6bVgUlVYrayrVWKyr1J9agQRFBUAFRqxGFIyII5Hv/2DthJkzITJI9M5l8Xs8zz8xee+/Z39kM883aa+21zN0RERGJUl6mAxARkdynZCMiIpFTshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkREIrdfpgPIlMMOO8yLiooyHYaISKeybNmyj9y9T6r7ddlkU1RURG1tbabDEBHpVMxsfVv202U0ERGJnJKNiIhETslGREQi12XbbERkj507d7Jx40a2b9+e6VAkS/To0YP+/fvTvXv3Dnk/JRsRYePGjfTs2ZOioiLMLNPhSIa5O5s2bWLjxo0MHDiwQ95Tl9FEhO3bt3PooYcq0QgAZsahhx7aoTVdJRsRAVCikTgd/X1QshERkcgp2YhI1ioqKuKjjz4C4Etf+lKb3mPJkiX06tWLESNGcNxxx3HKKafw0EMPNa2fMWMGRx55JMXFxRx//PFMmzaNhoaGDolf9lCyEZGcN3r0aF5++WVWr17N7Nmzueyyy3j88ceb1ldUVFBXV8fKlSt59dVX+dvf/pbBaHOTko2IpKymBoqKIC8veK6paf97Tpo0iZKSEgYPHkx1dXWL27k7V199NUOGDGHo0KEsWLAAgAsvvJA//elPTduVlZXx4IMP7rV/cXEx1113Hbfeeute67744gu2b99O79692/+BJI6SjYikpKYGpk6F9evBPXieOrX9CeeOO+5g2bJl1NbWMnv2bDZt2pRwuwceeIC6ujqWL1/O4sWLufrqq3n//fe5+OKLmTt3LgBbtmzhueee45vf/GbC9xg5ciSrVq1qWq6srKS4uJh+/fpx7LHHUlxc3L4PI3tRshGRlEyfDtu2xZdt2xaUt8fs2bMZPnw4J510Eu+88w5r1qxJuN0zzzzD+eefT7du3ejbty9jxozhxRdfZMyYMaxZs4b6+nruuecevvOd77DffolvJXT3uOXGy2gffvghn332Gffee2/7PozsRclGRFKyYUNq5clYsmQJixcv5vnnn2f58uWMGDGiTfd4XHjhhcyfP58777yTiy66qMXtXn75ZQYNGrRXeffu3ZkwYQJPPfVUyseWfVOyEZGUDBiQWnkytmzZQu/evcnPz2fVqlUsXbq0xW1Hjx7NggUL2L17N/X19Tz11FOceOKJAEyZMoVZs2YBcMIJJyTc/5VXXuEXv/gFl1566V7r3J1nn32Wo48+uu0fRhLScDUikpKZM4M2mthLafn5QXlbTZgwgdtuu41BgwZx3HHHcdJJJ7W47be//W2ef/55hg8fjpnxy1/+kiOOOAKAvn37MmjQICZNmhS3z9NPP82IESPYtm0bhx9+OLNnz2bcuHFN6ysrK5k/fz47d+5k2LBhXHLJJW3/MJKYu2fFA5gArAbWAtcmWH8AsCBc/wJQFLPuJ2H5auDryR2vxAsL3efPd5Eub+XKlSltP3++e2Ghu5ln1f+jzz77zI866ijfvHlzpkPJCbHfi8Z/cyhxb8NvfFZcRjOzbsAc4BvACcD5Zta8Dnwx8Im7fwWoBG4M9z0B+B4wmCBh/Tp8v1Z1VC8aka6mrAzWrYOGhuC5rCzTEcHixYsZNGgQl19+Ob169cp0ODkltgdiW2VFsgFOBNa6+1vu/gVwLzCx2TYTgXnh6/uAcRYM3jMRuNfdd7j72wQ1nBOTPXBH9KIRkcwbP34869ev58orr8x0KDknUQ/EVGVLsjkSeCdmeWNYlnAbd98FbAEOTXJfAMxsqpnVmlkt1DeVt6cXjYhIruuI38hsSTZp4e7V7l7q7qXQp6m8Pb1oRERyXUf8RmZLsnkX+HLMcv+wLOE2ZrYf0AvYlOS+LWpvLxoRkVw3c2bwW9ke2ZJsXgSOMbOBZrY/QYP/ombbLAImh6/PAZ5wdw/Lv2dmB5jZQOAY4O/JHLSwEKqrs6NxU0QkW5WVBb+VhYVtf4+sSDZhG8xlwKPA68Af3P01M/u5mZ0VbnY7cKiZrQWuAq4N930N+AOwEngEuNTdd7d2zJKS7OlFIyKJ3Xbbbdx1110AzJ07l/fee6/Fba+77joWL17cpuPU1dXx8MMPNy0vWrSIG264oU3v1dznn3/OmDFj2L07+Fm6+uqrGTx4MFdffXXc55syZQr33XcfALNmzWJbe1vk96Fxuob6+nomTJiQ1D6NPRBh2bI2HbQt/aVz4VFSUtJKD3ORriPV+2y8oWHfyxEYM2aMv/jiiwnX7dq1q13vfeedd/qll17arvdoya233uqzZs1qWj744IMTxjt58mRfuHChu7sXFhZ6fX19SsdJ5RwcdNBBTa+nTJnizzzzTMLtEn0vgFrvrPfZiEgnMmMGVFQEQz5D8FxREZS3w1133cWwYcMYPnw4F1xwQXioGfzqV7/ivvvuo7a2lrKyMoqLi/n8888pKirimmuuYeTIkSxcuDCuZlBUVMT111/PyJEjGTp0aNMIz3//+98ZNWoUI0aM4OSTT2b16tV88cUXXHfddSxYsIDi4mIWLFjA3LlzueyyywBYt24dp512GsOGDWPcuHFsCLtmTZkyhSuuuIKTTz6Zo446qunYzdXU1DBxYnAnx1lnncXWrVspKSlhwYIFTZ8v1uzZs3nvvfcYO3YsY8eOBeCvf/0ro0aNYuTIkZx77rls3bq16XPGnoM333yTCRMmUFJSwujRo5s+99tvv82oUaMYOnQo//mf/xl3vEmTJlGTjpsN25KhcuGhmo3IHknXbBoa3MvL3SF4TrTcBitWrPBjjjmm6a/5TZs2ubv79ddf7zfddJO7712zKSws9BtvvLFpuXnNYPbs2e7uPmfOHL/44ovd3X3Lli2+c+dOd3d/7LHH/Oyzz3b3vWs2scvf+ta3fO7cue7ufvvtt/vEiRObjnfOOef47t27/bXXXvOjjz56r8+1Y8cO79u3b1xZbK0i9vO1VLOpr6/30aNH+9atW93d/YYbbvCf/exnCc/Baaed5m+88Ya7uy9dutTHjh3r7u5nnnmmz5s3z92DmlZsDBs3bvQhQ4bsFbt7x9ZsNDaaiCTPDCorg9dVVcEDoLw8KDdr09s+8cQTnHvuuRx22GEAHHLIIUntd95557W47uyzzwagpKSEBx54AAgG/Jw8eTJr1qzBzNi5c2erx3j++eeb9r/gggv48Y9/3LRu0qRJ5OXlccIJJ/DBBx/ste9HH31EQUFBUp+lJUuXLmXlypV89atfBYIJ3kaNGtW0vvEcbN26leeee45zzz23ad2OHTsAePbZZ7n//vubPsM111zTtM3hhx++z7awjqJkIyKpaUw4jYkG2pVo2uOggw5qcd0BBxwAQLdu3di1axcAP/3pTxk7dix//OMfWbduHaeeemq7jt94DNh7jhyAAw88sE1TJcRyd772ta9xzz33JFzfeA4aGhooKCigrq4u4XbWwr/P9u3bOfDAA9sVYzLUZiMiqWlso4kV24bTBqeddhoLFy5smp3z448/3mubnj178umnn7b5GBDUbI48MhhgpHFWz9be++STT26aTK2mpobRo0cnfbzevXuze/fulBNObDwnnXQSzz77LGvXrgXgs88+44033thrn4MPPpiBAweycOFCIEhSy5cvB+CrX/1q3GeI9cYbbzBkyJCU4msLJRsRSV5joqmqCi6dNTQEz1VV7Uo4gwcPZvr06YwZM4bhw4dz1VVX7bXNlClT+OEPf9jUQaAtfvzjH/OTn/yEESNGNNV2AMaOHcvKlSubOgjEuuWWW7jzzjsZNmwYd999N1WxNboknH766TzzzDMp7TN16lQmTJjA2LFj6dOnD3PnzuX8889n2LBhjBo1Km5K61g1NTXcfvvtDB8+nMGDB/Pggw8CUFVVxZw5cxg6dCjvvht/z/uTTz7Z4vTZHckSVf26gtLSUq+trc10GCJZ4fXXX084c2VCM2bA5s17Lp01JqCCgnb3SMtFL730EpWVldx9992ZDiWhU045hQcffJDevXvvtS7R98LMlrl7aarHUZuNiKRmxowgwTS2ATS24WSgzaYzGDlyJGPHjmX37t1065bU7CdpU19fz1VXXZUw0XQ0JRsRSV3zxKJEs08XXXRRpkNIqE+fPnvNahoVtdmICJC4N5V0XR39fVCyERF69OjBpk2blHAECBLNpk2b6NGjR4e9py6jiQj9+/dn48aN1NfXt76xdAk9evSgf//+HfZ+SjbSecQ2Sidaljbr3r07AwcOzHQYksN0GU06h4gGfxSR9FCykeznHtzXEXvjYOONhZs3t+vOdRFJD11Gk+wX0eCPIpI+GkFAOg93yIupjDc0KNGIpFlbRxDQZTTpHCIY/DHb1NRAUVGQT4uKgmWRXKFkI9kvosEfs0lNDUydCuvXBx9n/fpgWQlHcoXabCT7mQWDPMa20TS24RQU5MSltOnTYdu2+LJt24LysrLMxCTSkdRmI51HDt9nk5eXuIJmFlTkRLKF2mwk9+Xw4I8DBqRWLtLZKNmIZIGZMyE/P74sPz8oF8kFSjYiWaCsDKqrobAwqLAVFgbLaq+RXKEOAiJZoqxMyUVyl2o2IiISOSUbERGJnJKNiIhETslGREQip2QjIiKRU7IREZHIZTzZmNkhZvaYma0Jn3u3sN3kcJs1ZjY5pnyJma02s7rwcXj6ohcRkWRkPNkA1wKPu/sxwOPhchwzOwS4Hvhn4ETg+mZJqczdi8PHh+kIWkREkpcNyWYiMC98PQ+YlGCbrwOPufvH7v4J8BgwIU3xiYhIO2VDsunr7u+Hr/8B9E2wzZHAOzHLG8OyRneGl9B+apZDozOKiOSItAxXY2aLgSMSrJoeu+DubmapznlQ5u7vmllP4H7gAuCuFuKYCkwFGKDhdEVE0iYtycbdx7e0zsw+MLN+7v6+mfUDErW5vAucGrPcH1gSvve74fOnZvZ7gjadhMnG3auBagjms0n9k4iISFtkw2W0RUBj77LJwIMJtnkUON3MeocdA04HHjWz/czsMAAz6w58C1iRhphFRCQF2ZBsbgC+ZmZrgPHhMmZWama/A3D3j4FfAC+Gj5+HZQcQJJ1XgDqCGtBv0/8RRERkXzQttIiIJE3TQouISNZSshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkQypqYGioogLy94rqnJdEQSlbSMjSYi0lxNDUydCtu2Bcvr1wfLAGVlmYtLoqGajYhkxPTpexJNo23bgnLJPUo2IpIRGzakVi6dW8rJxswOMrNuUQQjIl1HS1NKaaqp3NRqsjGzPDP7VzP7s5l9CKwC3jezlWZ2k5l9JfowRSTXzJwJ+fnxZfn5QbnknmRqNk8CRwM/AY5w9y+7++HAvwBLgRvN7PsRxigiOaisDKqrobAQzILn6mp1DshVrU4xYGbd3X1ne7fJNppiQEQkdZFNMRCbRMLZMPe5jYiISHNJ32cTzpr5TTPbBbwHvAK84u63RBWciIjkhlRu6hwN9Hf33WZ2JDAcGBZNWCIikktSSTYvAIcCH7r7u8C7wMORRCUiIjkllftsfgP8zcx+ZGajzaxXVEGJiEhuSSXZzAfuIqgNXQI8Z2ZvRhKViIjklFQuo2109/+OLTCzAzo4HhERyUGp1GzqzKw8tsDdd3RwPCIikoNSqdn0Bcab2TXAS8ByoM7dF0YSmYiI5Iykk427fxeaLp0NBoYC/wwo2YiIyD6lclPnIUAFcDiwErjL3edFFZh0Eu7BwFYtLYuIkFqbzb3Ap8D/A/KBZ8zsxEiiks5hxgyoqAgSDATPFRVBuYhIjFSSTR93/6W7PxT2SjsTmB1RXJLt3GHzZqiq2pNwKiqC5c2b9yQgERFS6yDwsZkNdfdXAdz9LTPLb20nyVFmUFkZvK6qCh4A5eVBuS6liUiMVqcYaNrQ7HjgPuBp4FXgBOBId/92dOFFR1MMdBB3yIupIDc0KNGI5LDIphiIsR0YSTCZ2uEEXZ/PT/WAkkMaL53Fim3DEREJpZJsHnD3L9z9D+4+w91/CxS3NwAzO8TMHjOzNeFz7xa2e8TMNpvZQ83KB5rZC2a21swWmNn+7Y1JkhDbRlNeHtRoysvj23BEREKtJhsz+66Z3QD0NLNBZha7T3UHxHAt8Li7HwM8Hi4nchNwQYLyG4FKd/8K8AlwcQfEJK0xg4KC+DaayspguaBAl9JEJE4y00IfCYwDbgZeBI4DNhNMoNbH3f+5XQGYrQZOdff3zawfsMTdj2th21OBH7n7t8JlA+qBI9x9l5mNAma4+9dbO67abDqI7rMR6VLa2mbTam+0cO6au8zsTXd/NjzYoUARsCrVAybQ193fD1//g2BYnGQdCmx2913h8kbgyA6ISZLVPLEo0YhIAql0fV5lZtMIOgq8Brzq7p8ns6OZLQaOSLBqeuyCu7uZRXax38ymAlMBBgwYENVhRESkmVSSzR+BxcA04A1glJm95e7Ht7aju49vaZ2ZfWBm/WIuo32YQkybgAIz2y+s3fQnmEG0pTiqCduZSktL1YItIpImqfRG6+nuPwc+cPcxBN2e/9ABMSwCJoevJwMPJrujBw1OTwLntGV/ERFJj1TvswHYYWYHuvv9wOkdEMMNwNfMbA0wPlzGzErN7HeNG5nZ0wQjTI8zs41m1tgJ4BrgKjNbS9CGc3sHxCQiIh0olctovwpHfl4A3GFmzwEF7Q3A3TcR9HZrXl4L/FvM8ugW9n8L0ICgIiJZLJn7bEaZmbn7/e7+sbvfDPwF+DJwduQRiohIp5dMzeZCYI6ZvQE8Ajzi7ndFG5aIiOSSZO6zmQZNA3F+A5hrZr0IGuYfAZ51992RRikiIp1aMpfRBgG4+yp3r3T3CcBpwDPAucAL0YYoIiKdXTKX0f5sZn8DrnP3dwDCmzkfDh8iIiL7lEzX5+OBl4CnzKzKzPpEHJOIiOSYVpNNOK3ALcAg4B3g72b2CzM7OPLoRETaqKYGioqCuf2KioJlyZykb+p09+3u/itgCPA5sMzMfhRZZCIibVRTA1Onwvr1wUDk69cHy0o4mZN0sjGzIjObQHCj5QDgU+C/ogpMRKStpk+Hbdviy7ZtC8olM1rtIGBmrxAM27+BYEqB1wkmObuVYEBOEZGssmFDauUSvWR6o00C3vbWZlkTEckSAwYEl84SlUtmJNNB4K1wnpljzOx2M7s1HYGJiLTVzJmQnx9flp8flEtmpDLq893AfcApAGY2xMw0bI2IZJ2yMqiuhsLCYPLYwsJguaws05F1XamM+pzn7n8xs/8CcPcVZjYkorhERNqlrEzJJZukUrN5z8wGAg5gZgYcGElUIiKdTfNmbTVzx0kl2VwJ/BY4wsx+ANwLrIgkKhGRzmTGDKio2JNg3IPlGTMyGVVWSeWmznXABOAK4Cjgb8AF0YQlItJJuMPmzVBVtSfhVFQEy5s3q4YTSuY+G2vs9uzuuwg6CdzX0jYiIl2KGVRWBq+rqoIHQHl5UG6WudiySDI1myfN7HIzi+uhbmb7m9lpZjYPmBxNeCIinUBswmmkRBMnmWQzAdgN3GNm75nZSjN7G1gDnA/Mcve5EcYoIpLdGi+dxYptw5GkZurcDvwa+LWZdQcOAz53981RBycikvVi22gaL501LoNqOKFk2myOA97wwE7g/ejDEumC3ON/lJovS3Yyg4KC+DaaxktqBQX6NwxZa+36ZvYqUEgw6OYrwKuNz+7+YeQRRqS0tNRra2szHYZIYMaMoOdS449V41/LBQXqPttZdJE/FsxsmbuXprpfMmOjDQX6ANOAMwm6Pf8H8IqZ/SPVA4pIM+o6mxuaJ5YcTDTtkdRwNe6+A3jRzLa6++WN5WbWO7LIRLoKdZ2VLiCVEQQgHKqmacH9kw6MRaTrUtdZyXGtJhszm2NmF5vZCEDffJEoqOus5LhkajbLgWJgFtAzvM9moZn9zMzOizY8kS6gedfZhobgObYNR6STS+Y+m+rYZTPrDwwDSoALgQXRhCbSRajrrHQBrXZ9jts4uJR2PvA9gvttjnf3XhHFFil1fZas00W6zkrn1tauz8nc1HksQYL5V2Ar8AdgjLu/HQ5bIyIdQV1nJYcl0/V5FfAicI67v9psnS4mi4hIq5LpIHA28DbwVzO728zODMdI6xBmdoiZPWZma8LnhPfumNkjZrbZzB5qVj7XzN42s7rwUdxRsYmISMdIZgSBP7n794CvAH8BpgIbzexO4OAOiOFa4HF3PwZ4PFxO5CZanqztancvDh91HRCTiIh0oFRm6vzM3X/v7mcCxwPPE4yR1l4TgXnh63nApBaO/zjwaQccT0RE0izVEQSAYOQAd69299M6IIa+7t44kvQ/gL5teI+ZZvaKmVWa2QEtbWRmU82s1sxq6+vr2xSsiIikrk3JJlVmttjMViR4TIzdLpxaOtVOBz8hqGn9E3AIcE1LG4YJstTdS/v06ZPqx5BMa95NXzc7pk1NDRQVQV5e8FxTk+mIpLNJaiDO9nL38S2tM7MPzKyfu79vZv2AlKYtiKkV7QjbkX7UjlAlW2kI/oypqYGpU2HbtmB5/fpgGaCsLHNxSeeSlppNKxYBk8PXk4EHU9k5TFCYmRG096zo0Ogk89IxBL9qTS2aPn1Pomm0bVtQLpKslEYQiCQAs0MJbhQdAKwHvuvuH5tZKfBDd/+3cLunCS6XfQnYBFzs7o+a2RME8+0YUBfus7W142oEgU4mNsE06qgh+FVr2qe8vMS51ywYxk26lsgmT4uau29y93Hufoy7j3f3j8Py2sZEEy6Pdvc+7n6gu/d390fD8tPcfai7D3H37yeTaKQTMuOSHfFD8F+yowMSjSYua9WAAamViySS8WQjkoxLpjnH3hY/BP+xt1VwybR2JoNw0MtVXw9HWc7Lg6qqYLmLzifTvDPAGWdAfn78Nvn5MHNmJqKTzkrJRrKfO8f9poIrqWIW5RgNzKKcK6niuN+0fwj+mt8bJU/F15pKnqqk5vddM9FMnRp0AnAPnufNg8mTobAwyL2FhVBdrc4Bkpq09EYTaRczPvECZlFOBZWAhc+w2ds/BP/0/3Bmfh5fa5r5eQXT/6OSsrKulXBa6gzw8MOwbl1GQmo7jaKdVTLeQSBT1EGgc9lvP9i924mfLNbp1s3Ytasdb+xOVV4F5WGtqYJKKglqUVWUU97QtS6l5UxnAHX6iEyn7SAgkozgvo7mP/rWdL9Hm5nhvfauNc2iHO/V9SYuy4nOAOr0kZ3cvUs+SkpKXDqXadPcu3Vzh+B52rSOed/5893zD2zw4FcoeOQf2ODz53fM+3cm8+e75+d7/LnI9853Lhoa3MvL4z9IeXlQLu0C1HobfnN1GU2EoGF8+nTYsCH4K37mzK7bAJ4z58I9uC7YqKGhy9VUo9DWy2hKNiKSe9xZ9Y0Kjn90z03Aq75ezvF/6VptcFFQm42ICMQlmtiu8sc/WsWqb7S/q7y0jbo+i0huMeORpQU8kqCrPEsLOF41m4zQZTQRyTlBF+69u8qbWefqwp2FdBlNRCQUdNXeu6t8p+rCnWOUbKTz0DQAkqSZMzWeW7ZRspHOYcaMPTfowZ4b9XQ3uCRQVhaM36bx3LKHko1kv5g7wu/oVUGeOXf00h3hsm9lZcF4bg0NwbMSTWapN5pkPzNqSivZ3M259NMqLqIKPoU53a6goLSSMvUukkQ0EGdWUc1GOoX6y37Gzt3xZTt3B+Uie9Fl16yjZCPZzx3b8glXMjuu+EpmY1s+0WU0iaeBOLOSLqNJp9CzJ/BpC+UiscLZV4EgwVSFQ9aUd93ZV7OBajaS/cwoHd+bOd2uiCue0+0KSsf31o+H7C024TRSoskoJRvpFIbdfz3jxsWXjRsXlIvspfHSWawKjYuWSUo2kv3CH47j/zo7uBTS0ADl5cGyfkCkudg2mpjvS1wbjqSd2mwk+5kF0/nGXnNvvERS0PVm05RWNH5fLr88/vvS0KDvSwYp2UjnMGNG/H0SjT8g+uGQRJYsgS1b9nxn3OHpp6FXr0xH1mXpMpp0Hs0TixKNJNLQECSaujpe61FCnjXwWo8SqKsLyjXsc0Yo2YhIbsnLo+aqZSy3YgbvrKOBbgzeWcdyK6bmqmXxU0VL2mg+GxHJOUVFsH59A063pjJjN4WFeaxbl7GwcoLmsxERCW1Y38BLlMSVvUQJG9brElqmKNmISG5paODV7iWMoI6XKcbYzcsUM4I6Xu1eojabDFGyEckWmhyuY+TlcdjRvVhuxYxkGZDHSII2nMOO7qU2mwzRWRfJBhqluEP1fX0JK+Yto7AwL5w8LY8V85bR9/UlmQ6ty8p4sjGzQ8zsMTNbEz73TrBNsZk9b2avmdkrZnZezLqBZvaCma01swVmtn96P4FIO2mU4kiUXZAXP3naBRn/uevSsuHsXws87u7HAI+Hy81tAy5098HABGCWmRWE624EKt39K8AnwMVpiFmk4zTeoNo4pEpe3p6hVnTjquSIjHd9NrPVwKnu/r6Z9QOWuPtxreyzHDgHWAvUA0e4+y4zGwXMcPevt3ZcdX2WrOMe357Q0KBEI1mnM3d97uvu74ev/wH03dfGZnYisD/wJnAosNndd4WrNwJHRhWoSGQ0SrHkuLQkGzNbbGYrEjwmxm7nQTWrxf9dYc3nbuAH7p5y/0Uzm2pmtWZWW19fn/LnEImERimWLiAtA3G6+/iW1pnZB2bWL+Yy2octbHcw8GdgursvDYs3AQVmtl9Yu+kPvLuPOKqBagguo7Xt04h0MI1qLV1ANoz6vAiYDNwQPj/YfIOwh9kfgbvc/b7Gcnd3M3uSoP3m3pb2F8l6GtVaclw2tNncAHzNzNYA48NlzKzUzH4XbvOXFxHjAAAIfElEQVRd4BRgipnVhY/icN01wFVmtpagDef29IYv0kE0qrXksIz3RssU9UYTyUKxtbtEy5Jxnbk3moiIRlHIcUo2IpJ5GkUh5ynZiGSLrjwQp1kwZXNxcfwoCsXFQbkupXV6SjYi2aCrX0Jyb5rKOU7jVM5dKfHmKCUbkUzTJaSg5nLzzXw8oDiu+OMBxXDzzarZ5AAlG5FM00Cc4M6qM67ikA3xNZtDNtSx6oyrukbCzXFKNiLZwIya0sq4oprSLpJoAMx45PlevEx8zeZlinnkebXZ5AIlG5EsUDPf2fyD+IE4N/+ggpr5XeQvenfsf7YwgjpmUY7RwCzKGUEd9j9qs8kFSjYimebOjksquHRXVdwP7aW7qthxSRcZiNMM71XALMqpoBIwKqhkFuV4L40PlwuyYWw0ka7NjHc+3fuHFmDLp13nh7bPnBlM/XeHzxs/rzH9wEqq53SNz5/rNFyNSBYoKoL16x2I/WF1CguNdesyE1Mm1NTA9OmwYQMMGAAzZ0JZWaajklgarkakE5s5E/Lz4/+Cz883Zs7MUEAZUlYG69YFU/qsW6dEk0uUbESyQFkZVFdDYWFw1aywMFjWj63kCrXZiGSJsjIlF8ldqtmIiEjklGxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCKnZCMiIpFTshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkREIqdkIyIikVOyERGRyJm7ZzqGjDCzT4HVmY4jSxwGfJTpILKEzsUeOhd76FzscZy790x1p648U+dqdy/NdBDZwMxqdS4COhd76FzsoXOxh5nVtmU/XUYTEZHIKdmIiEjkunKyqc50AFlE52IPnYs9dC720LnYo03nost2EBARkfTpyjUbERFJk5xPNmY2wcxWm9laM7s2wfoDzGxBuP4FMytKf5TRS+I8XGVmK83sFTN73MwKMxFnOrR2LmK2+46ZuZnlbC+kZM6FmX03/G68Zma/T3eM6ZLE/5EBZvakmb0c/j85IxNxpoOZ3WFmH5rZihbWm5nNDs/VK2Y2stU3dfecfQDdgDeBo4D9geXACc22uQS4LXz9PWBBpuPO0HkYC+SHr6fl4nlI9lyE2/UEngKWAqWZjjuD34tjgJeB3uHy4ZmOO4PnohqYFr4+AViX6bgjPB+nACOBFS2sPwP4C2DAScALrb1nrtdsTgTWuvtb7v4FcC8wsdk2E4F54ev7gHFmZmmMMR1aPQ/u/qS7bwsXlwL90xxjuiTznQD4BXAjsD2dwaVZMufi34E57v4JgLt/mOYY0yWZc+HAweHrXsB7aYwvrdz9KeDjfWwyEbjLA0uBAjPrt6/3zPVkcyTwTszyxrAs4TbuvgvYAhyalujSJ5nzEOtigr9aclGr5yK8JPBld/9zOgPLgGS+F8cCx5rZs2a21MwmpC269ErmXMwAvm9mG4GHgcvTE1pWSvU3pUuPICAJmNn3gVJgTKZjyQQzywNuBqZkOJRssR/BpbRTCWq7T5nZUHffnNGoMuN8YK67/x8zGwXcbWZD3L0h04F1Brles3kX+HLMcv+wLOE2ZrYfQfV4U1qiS59kzgNmNh6YDpzl7jvSFFu6tXYuegJDgCVmto7gevSiHO0kkMz3YiOwyN13uvvbwBsEySfXJHMuLgb+AODuzwM9CMZM64qS+k2JlevJ5kXgGDMbaGb7E3QAWNRsm0XA5PD1OcATHraA5ZBWz4OZjQB+Q5BocvW6PLRyLtx9i7sf5u5F7l5E0H51lru3aTyoLJfM/48/EdRqMLPDCC6rvZXOINMkmXOxARgHYGaDCJJNfVqjzB6LgAvDXmknAVvc/f197ZDTl9HcfZeZXQY8StDb5A53f83Mfg7Uuvsi4HaC6vBaggax72Uu4mgkeR5uAr4ELAz7R2xw97MyFnREkjwXXUKS5+JR4HQzWwnsBq5291yr+Sd7Lv4X8FszqyDoLDAlB/8wBcDM7iH4I+OwsI3qeqA7gLvfRtBmdQawFtgG/KDV98zRcyUiIlkk1y+jiYhIFlCyERGRyCnZiIhI5JRsREQkcko2IiISOSUbkSSZ2RFmdq+ZvWlmy8zsYTM7NoX9jzezunDU4KPbGUtx7KjDZnbWvkawFsk0dX0WSUI4OOtzwLzwPgPMbDhwsLs/neR7XAvs5+7/O8F7WyrDnpjZFILRqC9Ldh+RTFLNRiQ5Y4GdjYkGwN2Xu/vTZnaqmT3UWG5mt4bJgJiyM4ArgWnhnChF4dwpdwErgC+b2f81s9pw3pifxez7T2b2nJktN7O/m1kv4OfAeWFN6Twzm2Jmt4bbF5nZE7ZnbqIBYfnccA6S58zsLTM7J7rTJRJPyUYkOUOAZW3d2d0fBm4DKt19bFh8DPBrdx/s7uuB6e5eCgwDxpjZsHDolAVAubsPB8YDnwHXEcw5VOzuC5od7haCGtgwoAaYHbOuH/AvwLeAG9r6eURSldPD1YhkufXhXCCNvmtmUwn+X/YjmKDLgffd/UUAd/8fgFamXBoFnB2+vhv4Zcy6P4WX61aaWd8O+RQiSVDNRiQ5rwElLazbRfz/pR5JvudnjS/MbCDwI2BcWCP5cwrvk4rY0bxzbZJAyWJKNiLJeQI4IKx5ABBe5hoNrAdOMLMDzKyAcGTgFB1MkHy2hDWOb4Tlq4F+ZvZP4TF7hlNhfEowHUIiz7FnQNkyIKkODCJRUrIRSUI4uu+3gfFh1+fXgP8G/uHu7xDMc7IifH65De+/PNxvFfB74Nmw/AvgPOAWM1sOPEZQ43mSIMHVmdl5zd7ucuAHZvYKcAFQnmo8Ih1NXZ9FRCRyqtmIiEjklGxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCKnZCMiIpFTshERkcj9f378IyDXUQvnAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x10b129b38>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "plt.scatter(*zip(*points), color='blue', marker='o', label='alloyDB')\n",
+    "plt.scatter(*zip(*new_points), color='red', marker='x', label='citrination (filtered)')\n",
+    "plt.legend()\n",
+    "plt.xlim(0, 1)\n",
+    "plt.xlabel(\"Cu fraction\")\n",
+    "plt.ylabel(\"$\\Delta H (eV/atom)$\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  },
+  "nbpresent": {
+   "slides": {
+    "5c8082ad-f7f3-497a-91a5-b82f1bfa6d0e": {
+     "id": "5c8082ad-f7f3-497a-91a5-b82f1bfa6d0e",
+     "layout": "grid",
+     "prev": null,
+     "regions": {
+      "3fdabdaa-d1a7-4289-8161-39096a883c62": {
+       "attrs": {
+        "height": 1,
+        "pad": 0.01,
+        "treemap:weight": 1,
+        "width": 1,
+        "x": 0,
+        "y": 0
+       },
+       "content": {
+        "cell": "f2f733dc-95c8-4751-a337-7bba7fcbe4d7",
+        "part": "whole"
+       },
+       "id": "3fdabdaa-d1a7-4289-8161-39096a883c62"
+      }
+     }
+    },
+    "8e99069f-4d09-4e7b-8dbb-b8cf82a67ae2": {
+     "id": "8e99069f-4d09-4e7b-8dbb-b8cf82a67ae2",
+     "prev": "5c8082ad-f7f3-497a-91a5-b82f1bfa6d0e",
+     "regions": {
+      "1dabf2fc-3b38-4a0d-a95c-c4574fd5354f": {
+       "attrs": {
+        "height": 0.6,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "c41a4f53-9a6a-435e-b554-90780aa20fcd",
+        "part": "whole"
+       },
+       "id": "1dabf2fc-3b38-4a0d-a95c-c4574fd5354f"
+      },
+      "ab4f31d7-8029-4c39-854f-edaad678b711": {
+       "attrs": {
+        "height": 0.2,
+        "width": 0.4,
+        "x": 0.5,
+        "y": 0.7
+       },
+       "id": "ab4f31d7-8029-4c39-854f-edaad678b711"
+      },
+      "b3bd2bc4-2c69-4998-8fe0-a09a6c579492": {
+       "attrs": {
+        "height": 0.2,
+        "width": 0.4,
+        "x": 0.1,
+        "y": 0.7
+       },
+       "id": "b3bd2bc4-2c69-4998-8fe0-a09a6c579492"
+      }
+     }
+    }
+   },
+   "themes": {}
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/MLonCitrination-4.ipynb
+++ b/MLonCitrination-4.ipynb
@@ -1,0 +1,496 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "from os import environ\n",
+    "from pypif import pif\n",
+    "\n",
+    "\n",
+    "from citrination_client import PifSystemQuery, PifSystemReturningQuery\n",
+    "from citrination_client import FieldQuery, ValueQuery, NameQuery\n",
+    "from citrination_client import PropertyQuery,DataQuery, DatasetQuery, ChemicalFieldQuery, Filter\n",
+    "\n",
+    "client = CitrinationClient(environ['CITRINATION_API_KEY'], 'https://citrination.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Machine learning on Citrination\n",
+    "\n",
+    "Citrination will automagically generate machine learning models when given sufficient meta-data:\n",
+    " 1. A list of records (pifs)\n",
+    " 1. Identification of columns as inputs or outputs\n",
+    " 1. [Implicit] consistency of unlisted conditions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## CSV to Models\n",
+    "\n",
+    "User-defined machine learning is exposed via \"data views\":\n",
+    " 1. Put data into a CSV\n",
+    " 1. Upload as a dataset\n",
+    " 1. Include in a view\n",
+    " 1. ...\n",
+    " 1. Models!\n",
+    " \n",
+    "In this tutorial, we'll generate a valid CSV from a query.  You can also use any CSV you might have laying around."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Example: density from MaterialsProject\n",
+    "\n",
+    "We'll train a model from chemical formula to density using [data](https://citrination.com/search/simple?property=density&includedDatasets=150675) from the [materials project](https://materialsproject.org/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Let's start with a simple query for the density that extracts it along with the formula"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "system_query=PifSystemQuery(\n",
+    "                chemical_formula=ChemicalFieldQuery(\n",
+    "                    extract_as=\"formula\"\n",
+    "                ),\n",
+    "                properties=PropertyQuery(\n",
+    "                    name=FieldQuery(\n",
+    "                        filter=[Filter(equal=\"Density\")]\n",
+    "                    ),\n",
+    "                    value=FieldQuery(\n",
+    "                        extract_as=\"density\",\n",
+    "                        extract_all=True)\n",
+    "                    )\n",
+    "                )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Material's project is big, so we'll just pull out 500 records for now.  If we don't draw them randomly, they'll all be `Al` and `As` and `Cs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dataset_id = '150675'\n",
+    "\n",
+    "test_query = PifSystemReturningQuery(\n",
+    "                size=500,\n",
+    "                random_results=True,\n",
+    "                query=DataQuery(\n",
+    "                    dataset=DatasetQuery(\n",
+    "                        id=[Filter(equal='150675')]\n",
+    "                    ),\n",
+    "                    system=system_query\n",
+    "                ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Let's see what we've got:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We found 500 records\n",
+      "[{'density': ['6.741920951056403'], 'formula': 'W25O73'}, {'density': ['4.035981296421682'], 'formula': 'Li4VCr3O8'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "search_result = client.search.pif_search(test_query)\n",
+    "print(\"We found {} records\".format(len(search_result.hits)))\n",
+    "print([x.extracted for x in search_result.hits[0:2]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Now we just need to format in a CSV. The csv needs headers that conform to our [CSV template](http://help.citrination.com/knowledgebase/articles/1188136-citrine-template-csv-csv)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def write_csv(name, rows):\n",
+    "    with open(name, \"w\") as f:\n",
+    "        f.write(\"FORMULA, PROPERTY: Density\\n\")\n",
+    "        for row in rows:\n",
+    "            f.write(\"{}, {}\\n\".format(row.get('formula'), row.get('density')))\n",
+    "            \n",
+    "write_csv('density.csv', [x.extracted for x in search_result.hits])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Upload that csv to the [new dataset page](https://citrination.com/datasets/new), making sure to use the `Citrine: Template CSV` from the dropdown menu, which will create a dataset of records with the chemical formula and density taken from the CSV."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "To train the models, we create a _data view_ based on the dataset we just created.  To create a data view:\n",
+    " 1. Go to the [data views page](https://citrination.com/data_views) and click \"Create new dataset\"\n",
+    " 1. Search for the property name \"Density\" and select the dataset you created before.  Advance with the \"NEXT >\" button in the top right corner\n",
+    " 1. Select the \"Chemical formula\" and \"Density\" properties (or \"Include all\")\n",
+    " 1. The Chemical formula should be recognized as an \"Inorganic Chemical Formula\" and \"Input\"; click the right arrow to advance to the next property\n",
+    " 1. The density should be recognized as a \"Real\" and \"Output\".  Enter \"Infinity\" for the Max value\n",
+    " 1. Review the annotations, click \"Next >\", name your data view, and click \"Save\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "When the models are done training, you'll have access to predictions, model reports, and other analysis via the new data view."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Data science\n",
+    "\n",
+    "We can do better than that!  Many of the DFT records are unstable or meta-stable.  What we really want are densities of stable phases, so let's filter on the energy above the convex hull."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stable_query = PifSystemQuery(\n",
+    "                    chemical_formula=ChemicalFieldQuery(\n",
+    "                        extract_as='formula'\n",
+    "                    ),\n",
+    "                    properties=[\n",
+    "                        PropertyQuery(\n",
+    "                            name=FieldQuery(\n",
+    "                                filter=[Filter(equal=\"Density\")]),\n",
+    "                            value=FieldQuery(\n",
+    "                                extract_as=\"density\",\n",
+    "                                logic=\"MUST\")\n",
+    "                        ),\n",
+    "                        PropertyQuery(\n",
+    "                            name=FieldQuery(\n",
+    "                                filter=[Filter(equal=\"Energy Above Convex Hull\")]),\n",
+    "                            value=FieldQuery(\n",
+    "                                extract_as=\"EACH\",\n",
+    "                                filter=[Filter(max='0.000000001')],\n",
+    "                                logic=\"MUST\")\n",
+    "                        )]\n",
+    ")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "Let's re-run with this new query, saving to `better_density.csv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We found 5000 records\n",
+      "[{'density': ['6.741920951056403'], 'formula': 'W25O73'}, {'density': ['4.035981296421682'], 'formula': 'Li4VCr3O8'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "dataset_id = 150675\n",
+    "query_size = 5000\n",
+    "\n",
+    "better_query = PifSystemReturningQuery(\n",
+    "                size=query_size,\n",
+    "                random_results=True,\n",
+    "                query=DataQuery(\n",
+    "                    dataset=DatasetQuery(\n",
+    "                        id=[Filter(equal=str(dataset_id))]\n",
+    "                    ),\n",
+    "                    system=stable_query\n",
+    "                ))\n",
+    "\n",
+    "\n",
+    "better_result = client.search.pif_search(better_query)\n",
+    "\n",
+    "print(\"We found {} records\".format(len(better_result.hits)))\n",
+    "print([x.extracted for x in search_result.hits[0:2]])\n",
+    "write_csv('better_density.csv', [x.extracted for x in better_result.hits])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Applying the model\n",
+    "\n",
+    "We can use the model to make predictions through the client.  The `predict` method expects the ID number of the data view and a list of inputs, where each input is a map from property names to property values.\n",
+    "\n",
+    "The result is a dictionary with a `candidates` member that is a list of maps from property names to values.  However, the values here are pairs of the form `(expected value, uncertainty)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 1\n",
+      "We predict the density of AlCu to be 7.464366567871429 +/- 2.178253940554062\n"
+     ]
+    }
+   ],
+   "source": [
+    "inputs = [{\"Chemical formula\": \"AlCu\"},]\n",
+    "resp = client.models.predict(\"27\", inputs)\n",
+    "print(len(inputs), len(resp))\n",
+    "prediction = resp[0].get_value('Density')\n",
+    "print(\"We predict the density of {} to be {} +/- {}\".format(inputs[0]['Chemical formula'], prediction.value, prediction.loss))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Elemental properties\n",
+    "\n",
+    "The model uses average elemental properties, based on [magpie](https://bitbucket.org/wolverton/magpie), to featurize the chemical formula.  The predictions contain those and any other latent features as well: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[['Min atomic radius plus max electronegativity difference for Chemical formula dopants', 0.0], ['mean of Elemental atomic volume for Chemical formula dopants', 0.0], ['mean of Non-dimensional work function for Chemical formula', 0.7004071932745081], ['mean of DFT volume ratio for Chemical formula dopants', 0.0], ['mean of Shear Modulus Melting Temp Product for Chemical formula dopants', 0.0]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "keys = list(resp[0].all_keys())\n",
+    "print([[key, resp[0].get_value(key).value] for key in keys[0:5]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Design\n",
+    "\n",
+    "Now that we have a model, we can optimize it over the space of materials.  Creating a good sampler is generally hard, so here we'll just screen our model over the compounds in ICSD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Highest density compound is Np1Al99 with rho=14.450434349941387 +/- 6.354853591092307\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(\"./example_data/icsd.dat\", \"r\") as f:\n",
+    "    compounds = [x.split()[0] for x in f.readlines()]\n",
+    "inputs = [{\"Chemical formula\": x} for x in compounds[:1000]]\n",
+    "resp = client.models.predict(\"27\", inputs)\n",
+    "results = [{\"formula\": r.get_value('Chemical formula').value, \\\n",
+    "      \"value\": r.get_value('Density').value, \\\n",
+    "      \"loss\": r.get_value('Density').loss} for r in resp]\n",
+    "best = sorted(results, key=lambda x: -x['value'])[0]\n",
+    "print(\"Highest density compound is {} with rho={} +/- {}\".format(\n",
+    "    best['formula'], best['value'], best['loss']\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tsneDemo-4.ipynb
+++ b/tsneDemo-4.ipynb
@@ -1,0 +1,407 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Citrination t-SNE API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial, we're going to learn to use Citrination to generate a useful data analysis called t-SNE. This data visualization technique enables you to represent a high dimensional set of data in fewer dimensions in a way that preserves the local structure of the data. In materials informatics, this allows you to create a two-dimensional plot of a set of materials where points corresponding to similar materials are grouped together in two-dimensional space. More information on t-SNE here: https://lvdmaaten.github.io/tsne/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial will teach you to create and export a two-dimensional t-SNE plot for any data on Citrination. The first step is to create a data view on the Citrination: https://citrination.com/data_views. Instructions for creating a data view can be found in [this tutorial](https://github.com/CitrineInformatics/learn-citrination/blob/master/Journal%20Paper%20to%20Model%20Demo.ipynb).\n",
+    "\n",
+    "We'll be using this data view: https://citrination.com/data_views/787 (view id 787) for this tutorial, which includes a model predicting experimental band gaps based on data compiled by W.H. Strehlow and E.L. Cook, which can be viewed in [this dataset](https://citrination.com/datasets/1160/show_search)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from citrination_client import CitrinationClient\n",
+    "import matplotlib.pyplot as plt\n",
+    "import os\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['Property Band gap', 'Property Color'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "client = CitrinationClient(api_key=os.environ[\"CITRINATION_API_KEY\"])\n",
+    "\n",
+    "tsne_dataviewid = \"4106\"\n",
+    "tsne = client.models.tsne(tsne_dataviewid)\n",
+    "print(tsne.projections())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `tsne` call returns a dictionary where the top level keys correspond to the properties that are being modeled. In this data view, the model inputs are Chemical formula and Crystallinity. Citrine represents a chemical formula by calculating over 50 material descriptors. The t-SNE plot reduces that into just 2 dimensions. Let's look at the t-SNE plot for Band gap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<citrination_client.models.projection.Projection object at 0x10f197c50>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(tsne.get_projection(\"Property Band gap\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- `x` is the x component of the t-SNE plot\n",
+    "- `y` is the y component of the t-SNE plot\n",
+    "- `z` is the property value (Band gap in this example)\n",
+    "- `uid` is the uid of the record on Citrination. You can find the record by going to https://citrination.com/pif/{uid}\n",
+    "- `label` is the list of the values of the model inputs for the record"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/seto/anaconda2/envs/tensorflow36/lib/python3.6/site-packages/matplotlib/cbook/deprecation.py:106: MatplotlibDeprecationWarning: Adding an axes using the same arguments as a previous axes currently reuses the earlier instance.  In a future version, a new instance will always be created and returned.  Meanwhile, this warning can be suppressed, and the future behavior ensured, by passing a unique label to each axes instance.\n",
+      "  warnings.warn(message, mplDeprecation, stacklevel=1)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEKCAYAAAA1qaOTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3XmcHHWd//HXOwkk3EGCCISY4IZ1AbmMEQWVQyAcGlRwUdGorIgoK6yLgrjLivJbXFwRvDBCICinIAseXEKA9UgwgUASzsihYcEQAuGGzMzn90d9O/QMM90109VT3TPvp496pOpbXd/6NBnnk6rvpYjAzMysUSPKDsDMzIYGJxQzMyuEE4qZmRXCCcXMzArhhGJmZoVwQjEzs0I4oZiZWSGcUMzMrBBOKGZmVohRZQfQasaNGxcTJ04sOwwzawMLFixYERGbNlLHfnuuF0+u7Kx/r7tevi4ipjVyr2ZzQulh4sSJzJ8/v+wwzKwNSHqk0TqeXNnJbddNqPu5kZs/MK7RezWbE4qZWYkC6KKr7DAK4YRiZlaiIFgd9V95tQM3ypuZlawrx//ykDRL0nJJi3s59yVJIalpr86cUMzMShQEnVF/y+l84DUN95K2AvYF/lJc5K/lhGJmVrIuou6WR0TcCqzs5dQZwJchZ0UD5DYUM7MSBdDZxN/zkqYDj0bEnZKadh9wQjEzK13OJ5BxkqrHNMyMiJm1LpC0LvBVstddTeeEYmZWogBW52sjWRERU/pZ/ZuASUDl6WQ8cLukqRHxeD/rqssJxcysREE07ZVXRCwCXl85lvQwMCUiVjTjfm6UNzMrU0Bnji0PSRcDfwT+XtIySUc0M/Se/IRiZlaibKR8QXVFfKTO+YkF3apXTihmZqUSnTS399VgcUIxMytR1ijvhGJmZg3KxqE4oZiZWQG6/IRiZmaN8hOKmZkVIhCdQ2QEhxOKmVnJ/MrLzMwaFohXYmTZYRTCCcXMrETZwEa/8jIzswK4Ud7MzBoWITrDTyhmZlaAriHyhFJqWpQ0S9JySYuryl4n6QZJD6Q/N07lknSWpKWS7pK0S9U1M9LnH5A0o6r8rZIWpWvOUrOXKzMz66esUX5U3a0dlP2cdT4wrUfZCcCNETEZuDEdA+wPTE7bkcCPIEtAwMnA24GpwMmVJJQ+85mq63rey8ysVJVG+XpbOyg1yoi4FVjZo3g6MDvtzwYOriq/IDJzgbGSNgf2A26IiJUR8RRwAzAtndswIuZGRAAXVNVlZtYyOkN1t3bQis9Rm0XEY2n/cWCztL8l8Neqzy1LZbXKl/VSbmbWMjxSfpBEREhqztqYVSQdSfYajQkTJjT7dmZm3XQNkV5erfgt/pZeV5H+XJ7KHwW2qvrc+FRWq3x8L+WvEREzI2JKREzZdNNNC/kSZmZ5ZJNDjqi7tYNWjPJqoNJTawZwVVX5J1Jvr12BVenV2HXAvpI2To3x+wLXpXPPSNo19e76RFVdZmYtIRCrY2TdrR2U+spL0sXAHsA4ScvIemudBlwm6QjgEeDD6eO/AQ4AlgIvAJ8CiIiVkr4B/Cl97pSIqDT0H03Wk2wd4Jq0mZm1jAg8sLEIEfGRPk7t3ctnA/h8H/XMAmb1Uj4f2L6RGM3Mmkse2GhmZo0LsieUelsefQwWP13SvWlA+JWSxjbruzihmJmVrMBG+fN57QDuG4DtI2IH4H7gxOIi784JxcysRIHoivpbrrp6GSweEddHREc6nEv33q+FaulxKGZmQ10Aqwdvrq5PA5c2q3InFDOzUinveijjJM2vOp4ZETNz30U6CegALuxngLk5oZiZlSjIPVJ+RURMGcg9JH0SOAjYO/WYbQonFDOzkjVzxUZJ04AvA++JiBeadiOcUMzMShWhwuby6mOw+InAaOCGtCTU3Ig4qpAb9uCEYmZWoqxRvpipVfoYLH5uIZXn4IRiZlYqrylvZmYFyBrlh8bUK04oZmYla5fp6etxQjEzK1FlpPxQ4IRiZlayLj+hmJlZoyJgdZcTipmZNSh75eWEYmZmBWjmSPnB5IRiZlYidxs2M7OC+JWXmZkVZKisKe+EYmZWoqyXVzFzeZXNCcXMrEQe2GhmZoXxKy8zM2uYe3mZmVlh3MvLzMwaFiE6nFDMzKwIfuVlZmYNG0ptKH0+Z0kaKemzkr4habce577W/NDMzIaHrlDdrR3UenH3Y+A9wJPAWZK+U3Xug02NysxsmKiMQxnqCWVqRHw0Ir4LvB1YX9IvJI2GIdJp2sysBXShulsekmZJWi5pcVXZ6yTdIOmB9OfGzfoetRLK2pWdiOiIiCOBhcBNwPrNCsjMbDiJgI6uEXW3nM4HpvUoOwG4MSImAzem46aoFeV8Sd0Ci4hTgPOAic0KyMxsuCnqlVdE3Aqs7FE8HZid9mcDBxcXeXd99vKKiMP7KD8HOKdZAZmZDSeDMJfXZhHxWNp/HNisWTdyt2Ezs5JFvoQyTtL8quOZETGzf/eJkBT9Cq4fnFDMzEqWs9F9RURMGUD1f5O0eUQ8JmlzYPkA6shlaIz3bwERwVmn/5JDp3+bCy/637LDMbN++PPdj3LtpfO443f309XVNaj3jmj6OJSrgRlpfwZwVcNB96HuE4qkGyNi73plw9V9dzzIRT+8nt/fcj8dG6xNx+vX50fn38zMM6/l2z+cwdveuk3ZIZpZH1a/0sEpR53Porl/BokRI8RGm6zPty89mk0222iQohCd+Xtx1a5JuhjYg+z12DLgZOA04DJJRwCPAB8u5Ga96DOhSBoDrJsC25hXx55sCGzZrIDaxa+umMtZx17IiOdepGOEeGnXiXSutzaMzH4wOseO4V++9DN+8z8nsMHYdUuO1sx6c/lPbuauuX/mlZdWryl7+aVXOP1fLua0C48atDhytqHkqCc+0sepQXkAqJUWPwssAN6c/qxsVwHfb35oxZA0TdJ9kpZKKqT/9Yonn+W7/3oxXSOgs+MVgg5i9eo1yQSAkSPo2GwD3nvkqUXc0sya4NpL5nVLJgBdncGS+Q/x/DMvDkoMlbm8hsJI+Vrdhs8EzpR0TER8bxBjKoykkcAPgH2AZcCfJF0dEXc3Uu8Hpv8XY55YCS+8lN3neVhnzj28vONWdEze/NUPdsHoZwf3fayZ5bf6lY6+z63uHJwgImtHGQrqtqFExPckvZNsMOOoqvILmhhXUaYCSyPiQQBJl5AN8hlwQrn6poWs/dgza5IJpHeBnV2MXvgXOrcaR4xZa825ESP7/oE1s3Lttt9buPbSeXT0SB5bTBzH2E0Gb0KQVlgCODVzHAS8C9gCeBFYDPw6IpbkqSNPo/xPgTeRTbtS+a8eQDsklC2Bv1YdLyObl2zAzvzZzYx49IneT44QIx9/mo6Jm0IE6gpeedcQ+aeH2RD08eP2Y/4t9/L0k8/x0guvsPboUYwcNZJ//XZfTRHFiwIb5QdK0teB9wFzgHlkXYvHANsAp6Vk86WIuKtWPXnGoUwBto0YKg9lryXpSOBIgAkTJtT87IbrrcNznX2/xgopSyYvrWbMspW8+K6xhcZqZsXZcOP1OPu647nll3ewZP5DbDFxHPsdOpWx4zYY1Dha4LfrbRFxch/nviPp9UDtX47kSyiLgTcAj9X7YAt6FNiq6nh8KusmjTadCTBlypSaf7XnffNjHPLjOb0+oKqji9Wbb8iop19g/YWP88wnxvHHY710jFkrGz1mLfY9dCr7Hjq1tBiK6uXVgHUljY6Il3s7GRHLyTEgMk9CGQfcLek2YM3NIuL9eSMt0Z+AyZImkSWSw4CPNlLh2I3WJwg0QtDVPfe8/JatYO21GL1kOc9vtymdI9dp5FZmNgxEtERC+SjwA0nXARcD10VEv3sl5Eko/9HfSltFRHRI+gJwHTASmJW3camW8+7+Dp/e5li61htNbLweXWuN4uU3b0ZstC6jHn+WzrHrsHqX0dz2n02bJdrMhpCyuwVHxAckbQh8ADgGOFfSVcDFEXFL3nrqtgSlyh4G1kr7fwJuH1DUJYiI30TENhHxpogoZFDIhL/bkqufmc3aEiNWPMeIgDErXma9e1Yyqmskb3rn1sw7/atF3MrMhoGI+lvzY4hnImJ2ROwPbA/cQbZa71/rXLpGnl5enyFrsH4dWW+vLYGzGaSRl61q3fXX5dpnfgrA18/+NXN+dx/jNt2A8/9zBuuOWbvO1WZmmUB0ldzLq1qaGeWDwD+S/d6/PO+1eV55fZ5sPMc8gIh4ILX4W3LyUQdy8lEHlh2GmbWpsjt5SVqf7HXXR4CdySaU/AZwc396+OZJKC9HxCuSKjceRfnf38xsaGiNRvmHgWuBH5I1yK+u/fHe5Ukot0j6KrCOpH2Ao4FfDuRmZmbWi/L/ib5VRLwIIGkdSVtHxH39rSTPi7sTgCeARWQTRv4G8OAKM7OCRKju1tz7r0km7yObFeXadLyTpKvz1pNnLq8u4CdpMzOzAgXQ1VX6K6+K/yBrM78ZICIWpnF8ueTp5bVbuskb0+eV3Se27n+sZmbWTQDlt6FUrI6IVZU286TQRvlzgePI1kIZpPmczcyGjxaYy6tiiaSPAiMlTQb+GfhD3ovztKGsiohrImJ5RDxZ2QYarZmZ9RA5tsFxDLAd2TRbFwGrgGPzXpznCWWOpNOBX9B9Lq+2GS1vZta6mt/onldEvACclLZ+y5NQKuuHTKm+L7DXQG5oZmY9lPzKS9JPgLMiYlEv59YjGzX/ckRcWKuePL289hxwlGZmVltAlN/L6wfAv0l6C9mSJU+QLbA1GdgQmAXUTCaQr5fXRsDJwLtT0S3AKRGxamBxm5lZd8UkFEnHAf9E9syzCPhURLxU+6qsezDw4TQFyxRgc7IlgO/pzwDHPI3ys4BngQ+n7RngvLw3MDOzOgpolJe0JVmvrCkRsT3Zkh2H9SuMiOci4uaIuDgi/qe/o+XztKG8KSI+VHX8dUkL+3MTMzOrobg2lFFk02StBtYF/q+wmnPI84TyoqTdKwdpoOOLzQvJzGwYqQxsrLfVqybiUeDbwF/IlmxfFRHXNzf47vI8oXwOmJ3aUgSsBGY0NSozs2Ek58DGcZLmVx3PjIiZlYO0jsl0YBLwNPBzSYdHxM/6G09avTEi4tn+XJenl9dCYMd0AyLimf4GZ2ZmNeTr5bUiIqbUOP9e4KGIeAJA0i+AdwK5E4qkt5G1m2+QHepp4NMRsSDP9XVfeUnaRNJZZJOFzZF0pqRN8gZoZma1KepvOfwF2FXSusom49obuKefoZwLHB0REyPijWQLLObuhJWnDeUSsj7JHwIOSfuX9jNIMzPrTZ4eXjkSSkTMI1uu93ayLsMjgJk1L3qtzoj436o6fwd05L04TxvK5hHxjarjb0r6x34EaGZmfcrX6J5HRJxMNm5woG6R9GPgYrI09o/AzZJ2SfXXnHIrT0K5XtJhwGXp+BDguoHHa2Zm3bTObMM7pj97JqWdyTHlVp6E8hmy2SYrDTsjgOclfZasF8CG+WM1M7PX6Co7gEyjU23l6eW1QSM3MDOzGlprgS0kHUg2hf2YSllEnJLn2jxPKEjaAZhY/fmI+EW/ojQzs17l7MXVdJLOJhthvydwDlkTx215r88zOeQsYAdgCa8+mAXZ+ihmZtaoFkkowDsjYgdJd0XE1yX9N3BN3ovzPKHsGhHbDjw+MzNrE5VptV6QtAXwJNnMw7nkGYfyR0lOKGZmTVLQwMYi/ErSWOB0svEsD5N1Ic4lzxPKBWRJ5XGyJYBF1rtrh/7HamZm3QR5p15puqoxh1dI+hUwpj9rX+VJKOcCHycbedkindvMzIaQFmlDkfTBXspWAYsiYnm96/MklCci4uqBBGdmZvW1Si8v4AjgHcCcdLwHsACYJOmUiPhprYvzJJQ7JF0E/JLslRfgbsNmZoVpnYQyCviHiPgbgKTNyJo93g7cCjScUNYhSyT7VpW527CZWVFaJ6FsVUkmyfJUtjKtAllTnpHyn2okOjMz69sg9+Kq5+bUGP/zdPyhVLYe2aJdNeVZD2W8pCslLU/bFZLGNxazmZmt0aX62+CorH+yU9ouAD4fEc/nmecrzyuv84CLgEPT8eGpbJ8BhWtmZt20yhNKRARwRdr6Lc/Axk0j4ryI6Ejb+cCmA7mZmZn1ooAFtlpBnoTypKTDJY1M2+Fkw/HNzKxROUbJt8oTTD15EsqngQ8DjwOPkc0+6YZ6M7OiDJcnlIh4JCLeHxGbRsTrI+LgiPhLIzeVdKikJZK6JE3pce5ESUsl3Sdpv6ryaalsqaQTqsonSZqXyi+VtHYqH52Ol6bzExuJ2cysWdRVf2vq/aVFku7qa8tbT58JRdLpaVXGnuWflXTaQANPFgMfJBsoU133tsBhZIu7TAN+WHnVBvwA2B/YFvhI1YSV3wLOiIi/A54iG+lJ+vOpVH5G+pyZmb3WQcD7gGvT9rG0/SZtudR6QtkLmNlL+U/SzQcsIu6JiPt6OTUduCQiXo6Ih4ClwNS0LY2IByPiFeASYLokpTgvT9fPBg6uqmt22r8c2Dt93systZT8yiu9iXoE2CcivhwRi9J2At0HtddUK6GMTl3Iet64i2zG4WbYEvhr1fGyVNZX+SbA0xHR0aO8W13p/Kr0eTOz1lFgo7yksZIul3SvpHskvaOf0UjSblUH7yRfWztQexzKi5ImR8QDPe42mVcXYakV1W+BN/Ry6qSIuCpvgINB0pHAkQATJkwoORozG3aKewI5E7g2Ig5J7cnr9vP6I4BZkjYie3B4iqxjVi61Esq/A9dI+ibZbJMAU4ATgWPrVRwR780bRJVHga2qjsenMvoofxIYK2lUegqp/nylrmWSRgEb0Ud354iYSXq9N2XKlDbpT2FmQ0YBv3VSEng38EmA1DzwSr/CiFgA7Jjqoj9roUCNhBIR10g6GDgeOCYVLwY+FBGL+nOTfrgauEjSd4AtgMnAbWSZcrKkSWSJ4jDgoxERkuaQdWW+BJgBXFVV1wzgj+n8Tb29wjMzK5MorBfXJOAJ4DxJO5I9CHwxIp7PHYs0mmz+ronAqEqzc0Sckuf6mlOvRMRisl/KhZL0AeB7ZCPufy1pYUTsFxFLJF0G3A10kM0h05mu+QJwHTASmBURS1J1XwEuSU9Sd5AtCEb686eSlgIryZKQmVlryd9GMk7S/KrjmentSsUoYBfgmIiYJ+lM4ATg3/oRzVVk7c0LqFquJK88c3kVLiKuBK7s49ypwKm9lPfafS0iHiTrBdaz/CVenX/MzKx15UsoKyJiSo3zy4BlETEvHV9OllD6Y3xETOvnNWvkbr03M7MmKaDbcEQ8DvxV0t+nor3J3vb0xx8kvaWf16xRyhOKmZm9qsC5uo4BLkw9vB6k/9Nk7Q58UtJDZK+8RDYJ8Q55Lu4zoUi6LCI+nPa/FRFfqTp3fUTkHuxiZmY1FJRQImIhWW/cgdq/kfvXeuU1uWq/59onnr7ezKwIUf5cXmtCeXXE/IsMYJx+rYRSqxJ3vzUzK0qLzDYs6f2SHgAeAm4BHgauyXt9rTaUdSXtTJZ01kn7Sts6A47YzMy6aaH1Tr4B7Ar8NiJ2lrQn2Sq9udRKKI8D3+llv3JsZmZFaJ2EsjoinpQ0QtKIiJgj6bt5L641Un6PQsIzM7O+tdYCWk9LWp9saZELJS0Hco+0r9XL6921LoyIW2udNzOz+kRLvfKaTtYgfxzZeigbAbmmXYHar7yO76UsgB3IJl0cmT9GMzPrS6sklKp5v7ok/Rp4sj9zINZ65fW+6uM0R/7XyNpPjun1IlvjxRde5o+33Mfzz77Ezm/fmvFvHFd2SGbWqkpOKJJ2BU4jm/fwG8BPgXHACEmfiIhr89RTd6S8pL3JJhcL4P9FxA0DjnqYWHLnX/jaMT8jIujszDqQTzt4F44+/gC8aKSZvUb5TyjfB75K9orrJmD/iJgr6c3AxWTLAtdVqw3lQOAkspknvxYRv2s45GGgs6OTk4+7iBee7z5R5/VX38Hb3jmZqbtvU1JkZtaS+rEiYxONiojrASSdEhFzASLi3v78I7jWwMZfki1Y1QF8WdLV1VsDgQ9pixf+hc6O1w5rfenF1Vz7Pwt6ucLMhr3yBzZW/9LquSJv420owJ79CscA6OglmVSsXt05iJGYWbsYrKlVathR0jOkgetpn3Q8Jm8ltRrlb6k+lrQWsD3waEQs73+8w8P2O02gq+u1CX3MOmux1/47lhCRmbW6sl95RUQhvXb7fOUl6WxJ26X9jYA7gQuAOyR9pIibD0Wjx6zF8ad8gNGjRzFqrezvaMw6a7PDWyfx7n22Kzk6M2s5eV53ld/GkkutV17vioij0v6ngPsj4mBJbyCbLOzipkfXpnbfa1smX7EFN/76Tp5Z9SJv220yO0+dxIgRXs/MzHrRJgmjnloJ5ZWq/X2An0O2Kpi7vta32eZj+eg/vafsMMysxbXYSPmG1EooT0s6CHgU2A04AkDSKDzbsJlZYdRLu2s7qpVQPgucBbwBODatVwzZOsW/bnZgZmbDQhu1kdRTq5fX/cC0XsqvA65rZlBmZsPJUHnl1a9WYkm3NysQM7Nhaxj08uqNW+PNzAo2LJ9QcNuJmVnxCnxCkTRS0h2SflV8oLXVTSiSvlXZj4iv9SwzM7MGRDb1Sr2tH74I3NOcYGvL84SyTy9l+xcdiJnZcFQZh1Jvy1WXNB44EDiniSH3qdb09Z8Djga2lnRX1akNgN83OzAzs2Ej/6KI9XwX+DLZ7+lBV6tR/iKyKVb+EzihqvzZiFjZ1KjMzIaRnE8g4yTNrzqeGREz19SRDURfHhELJO1RbIT51BqHsopscS1PBGlm1iz5G91XRMSUGud3A94v6QCyKec3lPSziDi88SDz8WyFZmYlK6JRPiJOjIjxETEROAy4aTCTCfR/HIqZmRWsBRbYKoQTiplZmYIiG+WzKiNuBm4utNIcnFDMzEo2VEbKO6GYmZXNCcXMzBo1XBbYMjOzZosYFgtsmZnZYBga+cQJxcysbEPllVcpAxslnS7pXkl3SbpS0tiqcydKWirpPkn7VZVPS2VLJZ1QVT5J0rxUfqmktVP56HS8NJ2fOJjf0cwslwC6ov7WBsoaKX8DsH1E7ADcD5wIIGlbshGe25EtP/zDNLf/SOAHZLMcbwt8JH0W4FvAGRHxd8BTwBGp/AjgqVR+RvqcmVnrGSIrNpaSUCLi+ojoSIdzgfFpfzpwSUS8HBEPAUuBqWlbGhEPRsQrwCXAdEkC9gIuT9fPBg6uqmt22r8c2Dt93syspRQ1fX3ZWmEur0+TzWoMsCXw16pzy1JZX+WbAE9XJadKebe60vlV6fNmZi1FXVF3awdNa5SX9FvgDb2cOikirkqfOQnoAC5sVhx5SDoSOBJgwoQJZYZiZsNNG73SqqdpCSUi3lvrvKRPAgcBe0esmcjmUWCrqo+NT2X0Uf4kMFbSqPQUUv35Sl3LJI0CNkqf7y3WmcBMgClTpgyRv1ozawfZwMah8WunrF5e08hWFXt/RLxQdepq4LDUQ2sSMBm4DfgTMDn16FqbrOH+6pSI5gCHpOtnAFdV1TUj7R9CNpXz0PhbM7OhpSvH1gbKGofyfWA0cENqJ58bEUdFxBJJlwF3k70K+3xEdAJI+gJwHTASmBURS1JdXwEukfRN4A7g3FR+LvBTSUuBlWRJyMys5QyVJ5RSEkrqytvXuVOBU3sp/w3wm17KHyTrBdaz/CXg0MYiNTNrMrehmJlZMdqnF1c9TihmZmXzKy8zM2tYeAlgMzMrip9QzMysEEMjnzihmJmVTV1D451XK8zlZWY2fAWFDGyUtJWkOZLulrRE0hebFnMf/IRiZlYiEUUNbOwAvhQRt0vaAFgg6YaIuLuIyvPwE4qZWdki6m91q4jHIuL2tP8scA+vzr4+KPyEYmZWtoJ7eaUVancG5hVacR1OKGZmZaq0odQ3TtL8quOZaab0biStD1wBHBsRzxQSY05OKGZmJcvZy2tFREypWY+0FlkyuTAiflFEbP3hhGJmVqp8bST1pCXOzwXuiYjvNFzhALhR3sysTEEhjfLAbsDHgb0kLUzbAU2NvQc/oZiZla2AcY0R8TuyBSBL44RiZlYyL7BlZmbFcEIxM7OGRUDn0JjLywnFzKxsfkIxM7NCOKGYmVnDAvCa8mZm1riAcBuKmZk1KnCjvJmZFcRtKGZmVggnFDMza1wxk0O2AicUM7MyBZBv+vqW54RiZlY2P6GYmVnjPPWKmZkVISA8DsXMzArhkfJmZlYIt6GYmVnDItzLy8zMCuInFDMza1wQnZ1lB1EIJxQzszJ5+nozMyuMuw2bmVmjAgg/oZiZWcPCC2yZmVlBhkqjvGKIdFcriqQngEcGePk4YEWB4Qw2x1++dv8Owy3+N0bEpo3cUNK16b71rIiIaY3cq9mcUAokaX5ETCk7joFy/OVr9+/g+Ie3EWUHYGZmQ4MTipmZFcIJpVgzyw6gQY6/fO3+HRz/MOY2FDMzK4SfUMzMrBBOKAWRNE3SfZKWSjqh5FhmSVouaXFV2esk3SDpgfTnxqlcks5Kcd8laZeqa2akzz8gaUZV+VslLUrXnCVJBca+laQ5ku6WtETSF9sp/lT/GEm3SbozfYevp/JJkual+14qae1UPjodL03nJ1bVdWIqv0/SflXlTf15kzRS0h2SftVusad7PJz+jhdKmp/K2uZnqG1FhLcGN2Ak8Gdga2Bt4E5g2xLjeTewC7C4quy/gBPS/gnAt9L+AcA1gIBdgXmp/HXAg+nPjdP+xuncbemzStfuX2DsmwO7pP0NgPuBbdsl/lS/gPXT/lrAvHS/y4DDUvnZwOfS/tHA2Wn/MODStL9t+lkaDUxKP2MjB+PnDfgX4CLgV+m4bWJP938YGNejrG1+htp18xNKMaYCSyPiwYh4BbgEmF5WMBFxK7CyR/F0YHbanw0cXFV+QWTmAmMlbQ7sB9wQESsj4ingBmBaOrdhRMyN7P9ZF1TVVUTsj0XE7Wn/WeAeYMt2iT/FHRHxXDpcK20B7AVc3sd3qHy3y4G90794pwOXRMTLEfEQsJTsZ62pP2+SxgMHAuekY7VL7HW0zc9Qu3LukjR0AAAF90lEQVRCKcaWwF+rjpelslayWUQ8lvYfBzZL+33FXqt8WS/lhUuvT3Ym+xd+W8WfXhktBJaT/SL6M/B0RHT0ct81sabzq4BN6nyHZv68fRf4MlCZYGqTNoq9IoDrJS2QdGQqa6ufoXbkubyGoYgISS3dvU/S+sAVwLER8Uz1K+p2iD8iOoGdJI0FrgTeXHJIuUg6CFgeEQsk7VF2PA3YPSIelfR64AZJ91afbIefoXbkJ5RiPApsVXU8PpW1kr+lR3XSn8tTeV+x1yof30t5YSStRZZMLoyIX7Rb/NUi4mlgDvAOslcplX/EVd93Tazp/EbAk/T/uxVhN+D9kh4mex21F3Bmm8S+RkQ8mv5cTpbQp9KmP0NtpexGnKGwkT3pPUjW+FhpaNyu5Jgm0r1R/nS6N0j+V9o/kO4Nkrel8tcBD5E1Rm6c9l+XzvVskDygwLhF9k76uz3K2yL+VP+mwNi0vw7wv8BBwM/p3rB9dNr/PN0bti9L+9vRvWH7QbJG7UH5eQP24NVG+baJHVgP2KBq/w/AtHb6GWrXrfQAhspG1lPkfrJ35SeVHMvFwGPAarL3u0eQvde+EXgA+G3V/zEE/CDFvQiYUlXPp8kaU5cCn6oqnwIsTtd8nzRAtqDYdyd7/30XsDBtB7RL/Kn+HYA70ndYDPx7Kt86/SJamn5Bj07lY9Lx0nR+66q6Tkpx3kdVT6LB+Hmje0Jpm9hTrHembUnlHu30M9Sum0fKm5lZIdyGYmZmhXBCMTOzQjihmJlZIZxQzMysEE4oZmZWCCcUazpJYyUdXeP830u6Oc0Me4+kmal8D0kh6X1Vn/1VZQR3uua+dN1CSZf3Uf/+kuYrm8H4Dkn/XfBXHHSSjpW0bh/nvpBmwQ1J4wY7Nhu+nFBsMIwlm5W2L2cBZ0TEThHxD8D3qs4tIxvP0JePpet2iohDep6UtD3ZOIHDI2JbsvEDS/v9DVrPsUCvCQX4PfBe4JHBC8fMCcUGx2nAm9JTxOm9nN+cqsn2ImJR1bk7gVWS9hngvb8MnBoR96a6OyPiR5BNPinpprQGxo2SJqTy8yX9SNJcSQ+mJ6VZ6enp/ErFkp6TdIayNU9ulLRpKt8pXXuXpCur1t24WdK3lK2Vcr+kd6XykZJOl/SndM1nU/ke6ZrLJd0r6cK0dsc/A1sAcyTN6fmFI+KOiHh4gP+9zAbMCcUGwwnAn9NTxPG9nD8DuEnSNZKOSxMqVjsV+FofdV9Y9cqrt2S1PbCgj2u/B8yOiB2AC8melCo2Jpt/6zjg6hTjdsBbJO2UPrMeMD8itgNuAU5O5RcAX0n1LqoqBxgVEVPJnjAq5UcAqyLibcDbgM9ImpTO7Zw+uy3ZCPDdIuIs4P+APSNizz6+m9mgc0Kx0kXEecA/kE3hsQcwV9LoqvO3AkjavZfLq1959ZasankH2SJSAD8lm/al4peRTSOxCPhbRCyKiC6yqTwmps90AZem/Z8Bu0vaiGwer1tS+WyyBc8qKpNdLqiqZ1/gE2m6+3lkU4RMTudui4hl6d4Lq64xazlOKDboJJ1aeaqolEXE/0XErIiYDnSQPVlUq/WUUssS4K0DuO7l9GdX1X7luK9lH/LMY1Spq7OqHgHHVCXGSRFxfY/P97zGrOU4odhgeJZsOV8AIuKkyi9PWLPG+Fpp/w1k/0LvNh14+gW7MdnEi/1xOvBVSduk+kdIOiqd+wPZDLkAHyObFbg/RgCVjgAfBX4XEauApyrtI8DHyV6H1XId8Lmq/wbbSFqvzjXd/puatQInFGu6iHgS+L2kxX20c+wLLJZ0J9kv1+Mj4vFePncq3dengO5tKL/t5d53kbVBXCzpHrIZYrdOp48BPiXpLrJf/F/s51d7HpgqaTHZuiGnpPIZwOmp3p2qyvtyDnA3cHuq68fUfxKZCVzbW6O8pH+WtIxsnY67JJ2T9wuZNcKzDZsNkKTnImL9suMwaxV+QjEzs0L4CcXMzArhJxQzMyuEE4qZmRXCCcXMzArhhGJmZoVwQjEzs0I4oZiZWSH+Pxid/r4b0USFAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x1103f8c18>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gap_projection = tsne.get_projection(\"Property Band gap\")\n",
+    "plt.scatter(gap_projection.xs, gap_projection.ys, c=gap_projection.responses)\n",
+    "plt.colorbar(label=\"Band gap (eV)\")\n",
+    "plt.xlabel(\"t-SNE Component 1\")\n",
+    "plt.ylabel(\"t-SNE Component 2\")\n",
+    "plt.axes().set_aspect('equal', 'datalim')\n",
+    "# plt.xlim(-2500,2500)\n",
+    "# plt.ylim(-500,3500)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When interpreting a t-SNE plot, keep in mind that the t-SNE components plotted on the x and y axes have no physical meaning. Since the t-SNE algorithm preserves the local structure of the data, we look at points that end up close together. Just from looking at the plot, we can see that there is a cluster of high bandgap materials that contains the material with the maximum band gap in the bottom right corner. Let's take a look at what those materials are.\n",
+    "\n",
+    "\n",
+    "(note: t-SNE is a non-deterministic algorithm, so the plot will change if the underlying Data View is retrained)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the coordinates and band gap values into a numpy array\n",
+    "coordinates_and_bg = np.zeros((len(gap_projection.xs), 3))\n",
+    "coordinates_and_bg[:,0] = gap_projection.xs\n",
+    "coordinates_and_bg[:,1] = gap_projection.ys\n",
+    "coordinates_and_bg[:,2] = gap_projection.responses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find the n materials closest to the target material, as specified by index\n",
+    "# based on cartesian distance in the t-SNE coordinates\n",
+    "def find_most_similar_materials(index, coordinates, n_materials=10):\n",
+    "    distances = np.linalg.norm(coordinates_and_bg[:,0:2] - coordinates_and_bg[index,0:2], axis=1)\n",
+    "    return np.argsort(distances)[1:n_materials+1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From inspecting this cluster of materials, we can see that the t-SNE plot has grouped highly ionic materials together, and that these materials have very high band gaps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Maximum band gap material:\n",
+      "Be1O1, Band gap: 14.5, URL: https://citrination.com/pif/1160/3/66756141934A40C0096E45068CE9B071\n",
+      "Similar materials:\n",
+      "B2O3, Polycrystalline, Band gap: 4.9, URL: https://citrination.com/pif/1160/3/C98CE9CE4C27BA625CF3478677A2D0C5\n",
+      "V1O2, Single crystalline, Band gap: 0.65, URL: https://citrination.com/pif/1160/3/DA5FA80CB61BDD6A092075F6817E42FD\n",
+      "V2O3, Single crystalline, Band gap: 0.1, URL: https://citrination.com/pif/1160/3/E694087444A1F8F0BD04E8934EE1A5F7\n",
+      "Ti1O2, Single crystalline, Band gap: 3.05, URL: https://citrination.com/pif/1160/3/F734845B82D2DEE1CB882ECEB37AEEC6\n",
+      "V1O1, Band gap: 0.3, URL: https://citrination.com/pif/1160/3/13A857F2BEA1AF21C9495CA6BFEE37BF\n",
+      "V4O7, Single crystalline, Band gap: 0.8, URL: https://citrination.com/pif/1160/3/157376D5171A19965C6D6218C8B4F01E\n",
+      "V2O5, Single crystalline, Band gap: 2.54, URL: https://citrination.com/pif/1160/3/CA4ED13625FFF3FFD77AA0446116B87B\n",
+      "Mg1O1, Single crystalline, Band gap: 7.69, URL: https://citrination.com/pif/1160/3/0A5A69057521F06C37687B8AAE2E0905\n",
+      "Cr1O2, Polycrystalline, Band gap: 0.23, URL: https://citrination.com/pif/1160/3/D45EB1BFD5F6EBEBD7E7D8BF3A43862C\n",
+      "Zr1O2, Band gap: 0.65, URL: https://citrination.com/pif/1160/3/C505DB1DA4187DA22A3252185B5335D9\n",
+      "-651.6577729506878 49984.637839736446 -13976.535209245418 573.5589153283767\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEKCAYAAAA1qaOTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3XucVXW9//HXe4aroiJiSgKCHbqgmSmappWmJl4SKys1i5STlubRfpVhdk6lWZknTcsyUrx0zEuaaakp3rPyAopcvCQZJoiigGgqt5nP74/1Hd0Mc1l79tqzNzPv53msx6z9XbfPpjnzcX2vigjMzMwq1VDrAMzMrGdwQjEzs0I4oZiZWSGcUMzMrBBOKGZmVggnFDMzK4QTipmZFcIJxczMCuGEYmZmhehT6wDqzdChQ2PUqFG1DsPM1gMzZsx4MSI2r+Qe++21YSxZ2pTvebNW3hIR4yt5XjU5obQyatQopk+fXuswzGw9IOnpSu+xZGkTD9wyMte5jcOeHFrp86rJCcXMrIYCaKa51mEUwgnFzKyGgmB15KvyqndulDczq7HmnP/XGUlTJS2WNKeNY1+VFJKqVm1WtwlF0nxJsyXNlDQ9lQ2RNE3Sk+nnpqlcks6TNE/SLEk7ltxnYjr/SUkTa/V9zMzaEgRNkW/L4RJgnUZ7SSOAjwD/Kjb6tdVtQkn2iogdImJc+jwZuD0ixgC3p88A+wNj0nYM8AvIEhDwbeB9wC7At1uSkJlZvWgmcm2diYh7gKVtHDoHOBly3KQC9Z5QWpsAXJr2LwUOKSm/LDL3AYMlDQP2A6ZFxNKIWAZMo43sbWZWKwE0Ebm2rpA0AVgYEY8UGngb6rlRPoBbJQXwy4iYAmwREYvS8eeALdL+VsAzJdcuSGXtlZuZ1Y08bx/J0JYmgGRK+tvYJkkbAN8kq+6qunpOKHtExEJJbwGmSXq89GBEREo2FZN0DFlVGSNH5usPbmZWhABW51+K/cWSJoA83gaMBh6RBDAceEjSLhHxXFmB5lC3VV4RsTD9XAxcR9YG8nyqyiL9XJxOXwiMKLl8eCprr7z1s6ZExLiIGLf55hUNejUzK0vkrO7qSpVXRMyOiLdExKiIGEVWS7NjNZIJ1GlCkbShpI1a9sle1+YANwAtPbUmAten/RuAz6XeXrsCy1PV2C3ARyRtmhrjP5LKzMzqQ0BTzq0zkq4A/ga8Q9ICSZOqHX6peq3y2gK4Lr2i9QF+ExF/kvQgcHX6R3oa+FQ6/ybgAGAe8BpwFEBELJV0OvBgOu+0iGirB4SZWU1kI+ULulfE4Z0cH1XQo9pUlwklIp4C3tNG+RJg7zbKAzi+nXtNBaYWHaOZWTFEE6p1EIWoy4RiZtZbZI3yTihmZlahbByKE4qZmRWg2W8oZmZWKb+hmJlZIQLRVJ8jOMrmhGJmVmOu8jIzs4oFYlU01jqMQjihmJnVUDaw0VVeZmZWADfKm5lZxSJEU/gNxczMCtDsNxQzM6tU1ijfM/4U94xvYWa2nnKjvJmZFabJ41DMzKxSHilvZmaFaXYvLzMzq1Q2OaQTipmZVSgQqz31ipmZVSoCD2w0M7MiqMcMbOwZadHMbD0VZG8oebbOSJoqabGkOSVlZ0l6XNIsSddJGlyt7+KEYmZWY0005NpyuAQY36psGrBdRGwP/B04pdjo3+SEYmZWQ4Fojnxbp/eKuAdY2qrs1ohYkz7eBwwv/ltk3IZiZlZDAazuvrm8jgauqtbNnVDMzGpK5ayHMlTS9JLPUyJiSq6nSKcCa4DLywwwNycUM7MaCsoaKf9iRIwr9xmSPg8cBOwdEVHu9Xk5oXSn5mZocLOVma2tmis2ShoPnAx8KCJeq9qDcKN891myBEaMgKVLOz/XzHqNCNEcDbm2zki6Avgb8A5JCyRNAn4GbARMkzRT0gXV+i5+Q+kG8598jt8f+CVOevZZzv7Af3LEHVPZcouqdQU3M2DhP1/gmil38ffZzzD6ncP45LF7sfWYLWsd1jqyRvlipl6JiMPbKL6okJvn4IRSZef+4AZuvPhefrQwa0fba+FDHLH/jzjgqN352gkH1jg6s55p3tyFfP3T57Nq5Wqam4L5Tyzi3ptn8f3LjmXsTqNqHV4rPWdN+Z7xLerQs08vZv9tTuQPU+9GWzQydsUiALZ9ZQHaeiA3XH0fK15fVeMozXqmC077PSteW0VzU9b+3NwUrHx9NT/7n2trHNm6skb5Ysah1JoTStGWLeO6yT/ntPedyKgX/8Xo1c9zwCtzWN2QvQyubujDwfMfZOsNXuXrHzoJHnkk25Ytq3HgZj3HEzP/1Wb5/McX0dTU3M3RdK7AkfI15SqvgsUPfsDHzjqLA2lktRqJ1wQLYcM1K4Hs56Q5tzKJW7NpRne9GFasgJNPhjPPrHH0Zj3DBhsN4OWlr65T3n9gPxoa6uu/9FtGyvcE9Z/yKiRpvKQnJM2TNLnaz7t1z8O5cMhuNAMbxioGNa1kUEomLQatycoGNa0CCb7/ffjBD6odmlmvMWHiHvQf2Hetsv4D+nLAEbsh1d8f72Yacm31rke/oUhqBM4H9gUWAA9KuiEiHq3WM793zg0MaHo7MxnIafyFDVlNf9Z9xV7Z0IdXBvRj6F13wc47Vyscs17p08ftzQvPvsTtv59Bv359WLVqDbvttx2f/9r+tQ5tHRGwurn+k0UePTqhALsA8yLiKQBJVwITgKollMblq+DlV3lCQzgqxnMB0xjGumOJljZuyGfOmcQdTiZmhWtsbODEH3ySiV/bn2fnv8iWI4cwZPONax1Wm7IqLyeU9cFWwDMlnxcA76vWwyKChhdffuPzahoYwoo2zx2y5lUGLdq0WqGYGTB4s0EM3mxQrcPoVDVHynennp5QcpF0DHAMwMiRIyu5DyrpCrwTz7OGBvrTzOs00kjQ1NjIwKbVrG5o4Iy+Htxo1tu1dBvuCXrGe1b7FgIjSj4PT2VriYgpETEuIsZtvvnmFT0wXnola2gH9uFfbMAaVtDInxjNAe//f/xhm51ZoT5s2LSKdz/y54qeZWY9QXFTr9RaT39DeRAYI2k0WSI5DDiimg/coI9YsTLo2yjet2YRr9GH72lX/vrOHVkxakt+svF4HmgYyXfmX8egG2+E1auhb9/Ob2xmPVZPWVO+RyeUiFgj6cvALUAjMDUi5lbzmRc+eg5Hbn08zZsO4MZ+O3DJVruzeNRW0NgATc30faWJP79tDIPufhq++11Ys8YJxawXy3p5FTOXV6316IQCEBE3ATd11/O2HPEWPnHSAVx77s2cv/FYVjYOpOGVFTS+3kS/V5pp7tfA5w79EGyxBfz8590VlpnVKQ9stA596eyjuO7lS1j1zq0YsGw1G/7rNQYsb2L10AGsGbERxx+1d61DNLM60oxybfXOCaVKNtpwA+788/cYdcROvLr9UF5/16Z84cR9uPeqr9U6NDOrIz1pcsgeX+VVS337NHLRf1e1D4CZ9QDrQw+uPJxQzMxqKEKscUIxM7MirA/VWXk4oZiZ1VCvGCkvqVHSsZJOl7R7q2Pfqn5oZma9Q09plO+o4u6XwIeAJcB5ks4uOfbxqkZlZtZLtIxD6ekJZZeIOCIifkI2Q+8gSb+T1B/Wgw7RZmbriaLGoUiaKmmxpDklZUMkTZP0ZPpZtWnOO0oo/Vp2ImJNRBwDzATuAOp/Pmgzs/VABKxpbsi15XAJML5V2WTg9ogYA9yePldFRxFOl7RWYBFxGnAxMKpaAZmZ9TZFVXlFxD3A0lbFE4BL0/6lwCHFRv+mdnt5RcSR7ZRfCFxYrYDMzHqTbpjLa4uIWJT2nwO2qNaD3G3YzKzGIn9CGSppesnnKRExJf9zIiRFWcGVwQnFzKzGypj48cWIGFfm7Z+XNCwiFkkaBiwu8/rcesZ4fzOz9VRE1ceh3ABMTPsTgesLCbwNnSYUSbfnKTMzs64QTc0NubZO7yRdAfwNeIekBZImAT8E9pX0JLBP+lwV7VZ5SRoAbEBWZ7cpb4492RjYqloBmZn1NmW0oXRynzi8nUPdsghTR20oxwInAW8FZvBmQnkZ+FmV4zIz6xV60lxeHXUbPhc4V9IJEfHTbozJzKz3iKwdpSfotJdXRPxU0vvJBjP2KSm/rIpxmZn1GvWwvG9q5jgI+ABZzdTrwBzgxoiYm+cenSYUSb8G3kY27UpTKg7ACcXMrEKRGuVrSdJ3gY8CdwL3k3UtHgC8HfhhSjZfjYhZHd0nzziUccDYiJ7yUmZmVl/q4K/rAxHx7XaOnS3pLcDIzm6SJ6HMAbYEFnV2opmZla+oXl4V2EBS/4hY2dbBiFhMjgGReRLKUOBRSQ8AbzwsIg7OG6mZmbUtoi4SyhHA+ZJuAa4AbomIpk6uWUeehPKdcm9qZmb51brbcER8TNLGwMeAE4CLJF0PXBERd+e9T55eXndL2hoYExG3SdoAaOxq4GZmtrY6aEMhIl4mm97+UkmbAYeSrdY7JCJG5LlHnqlXvgBcQ7YkMGSj5H/ftZDNzKxUIJqbG3Jt3SHNjPJx4NPAELK//7nkqfI6HtiFrCsZEfFkavE3M7MC1PoFRdIgsuquw4H3kk0oeTpwVzk9fPMklJURsUpSy4P7UPvvb2bWM9RHo/x84E/Az8ka5Fd35SZ5Esrdkr4JDJS0L3Ac8IeuPMzMzNpQ+/9EHxERrwNIGihpm4h4otyb5KmUmwy8AMwmmzDyJuBb5T7IzMzaFqFcW/We/0Yy+SjZrCh/Sp93kHRD3vvk6eXVDPwqbWZmVqAAmptrXuXV4jtkbeZ3AUTETEmj816cZy6v3dNDtk7nK3tObFN+rGZmtpYAat+G0mJ1RCxvaTNPclfI5anyugg4G9gD2Jlsbq+dy4mwHJK+I2mhpJlpO6Dk2CmS5kl6QtJ+JeXjU9k8SZNLykdLuj+VXyWpX7XiNjPrqoh8WzeYK+kIoFHSGEk/Bf6a9+I8CWV5RNwcEYsjYknL1uVw8zknInZI200AksYChwHbAuOBn0tqlNQInA/sD4wFDk/nApyZ7vUfwDJgUpXjNjMrX+Tcqu8Esr+xK4HfAMvJFlrMJU8vrzslnQX8jrXn8nqovDgrNgG4Mk1e9k9J88jq+gDmRcRTAJKuBCZIegz4MNkcNZCNAP0O8ItujdrMrEPVbXAvR0S8BpyatrLlSSjvSz/HlT6X7I91tXxZ0ueA6WRz8C8jG6F/X8k5C3hzbftnWpW/D9gMeCki1rRx/lokHQMcAzByZKczNJuZFavG3YYl/Qo4LyJmt3FsQ7JR8ysj4vKO7pOnl9deXY6yHZJuI5sSv7VTyd4gTif7Jz4d+DFwdNExlIqIKcAUgHHjxtW+R7iZ9R4BUfteXucD/y3p3WRLlrxAtsDWGGBjYCrQYTKBfL28NgG+DXwwFd0NnBYRy7sWN0TEPnnOS1nzj+njQqB0grLhqYx2ypcAgyX1SW8ppeebmdWRYhKKpK8A/0n2H+SzgaMiYkVn10XETOBTaQqWccAwsiWAHytngGOeRvmpwCvAp9L2MnBx3geUS9Kwko8fI8uWkM0tc5ik/qlf9BjgAeBBYEzq0dWPrOH+hjT/zJ1kM2YCTASur1bcZmZdVkCjvKStgP8CxkXEdmSzwh9WVhgR/46IuyLiioj4fbmj5fO0obwtIj5R8vm7kmaW85Ay/UjSDmT/fPPJRucTEXMlXQ08CqwBjm9ZAEbSl4FbyP4Bp0bE3HSvbwBXSvoe8DBZF2gzs/pSXEV7H7JpslYDGwDPFnbnnA/vzOuS9oiIe+GNgY6vVyugiPhsB8fOAM5oo/wmsilhWpc/xZs9wczM6k9BAxsjYqGk/wX+RfY3+taIuLXiG5chT0L5EtmCK5uQVfQtJas+MjOzApQxaHGopOkln6ekTkUt65hMAEYDLwG/lXRkRPxfufGk1RsjIl4p57o8vbxmAu9JD2hZ1cvMzIqSv5fXixExrp1j+wD/jIgXACT9Dng/kDuhSNqZrN18o+yjXgKOjogZea7Ps2LjZpLOI5ss7E5J56blIc3MrACKfFsn/gXsKmkDZZNx7Q08VmYoFwHHRcSoiNiabIHF3J2w8vTyupKsT/InyHpMvQBcVWaQZmbWlrw9vDpJKBFxP9lyvQ+RdRluII2vK0NTRPy55J73knWCyiVPG8qwiDi95PP3JH26jADNzKxdKmy24Yj4Ntm4wa66W9IvgSvIUtingbsk7Zju3+GUW3kSyq2SDgOuTp8PJeuia2ZmRaif+Tnek362TkrvJceUW3kSyhfIZptsadhpAF6VdCxZL4CN88dqZmbraK51AJlKp9rK08tro0oeYGZmHaivBbaQdCDZFPYDWsoi4rQ81+Z5Q0HS9sCo0vMj4ndlRWlmZm3K0YOrW0i6gGyE/V7AhWRNHA/kvT7P5JBTge2Bubz5YhZk66OYmVml6iShAO+PiO0lzYqI70r6MXBz3ovzvKHsGhFjOz/NzMzWcy3Tar0m6a1ks7YP6+D8teQZh/K3kiV1zcysYAUNbCzCHyUNBs4iG88yn6wLcS553lAuI0sqz5EtASyy3l3blx+rmZmtJShn6pWqKhlzeK2kPwIDyln7Kk9CuQj4LNnIyzrp3GZm1oPUSRuKpI+3UbYcmB0Rizu7Pk9CeSEibuhKcGZm1rl66eUFTAJ2I1ucEGBPYAYwWtJpEfHrji7Ok1AelvQb4A9kVV6Auw2bmRWmfhJKH+BdEfE8gKQtyJo93gfcA1ScUAaSJZKPlJS527CZWVHqJ6GMaEkmyeJUtjStAtmhPCPlj6okOjMza1839uDK467UGP/b9PkTqWxDskW7OpRnPZThkq6TtDht10oaXlnMZmb2hmbl26qvZf2THdJ2GXB8RLyaZ56vPFVeFwO/AT6ZPh+ZyvbtUrhmZraWenlDiYgArk1b2fIMbNw8Ii6OiDVpuwTYvCsPMzOzNhSwwFY9yJNQlkg6UlJj2o4kG45vZmaVyjlKvl7eYjqSJ6EcDXwKeA5YRDb7pBvqzcyK0kPeUPL08noaOLgbYjEz65VU4zlIJM2mg5SVd6qtdhOKpLOAeRHxy1blxwKjI2JyzljNzKy+HZR+Hp9+tgxg/Ew5N+moyuvDwJQ2yn9V8nAzM6tUjau8IuLpVBu1b0ScHBGz0zaZtQe1d6ijhNI/dSFr/eBmshmHzcysUgU2yksaLOkaSY9LekzSbmVGI0m7l3x4P/na2oGO21BelzQmIp5s9bQxvLkIi5mZVaq4t49zgT9FxKGS+pEt51uOScBUSZuQvTgsI+uYlUtHCeV/gJslfY9stkmAccApwEllBmlmZu0pIKGkJPBB4PMAEbEKWFVWGBEzgPeke1HOWijQQUKJiJslHQJ8HTghFc8BPhERs8t5iJmZtU0U1strNPACcLGk95C9CJwYEa/mjkXqTzZ/1yigj5S1bkTEaXmu77DbcETMASbmDcbMzMpU3qDFoZKml3yeEhEtnaf6ADsCJ0TE/ZLOBSYD/11GNNcDy8mS0cpOzl1Hnrm8zMysmvInlBcjYlw7xxYACyLi/vT5GrKEUo7hETG+zGvekLv13szMqqSAbsMR8RzwjKR3pKK9gUfLjOSvkt5d5jVvqElCkfRJSXMlNUsa1+rYKZLmSXpC0n4l5eNT2TxJk0vKR0u6P5VflXo2IKl/+jwvHR/VXd/PzKwcBc7ldQJwuaRZZNPPf7/MUPYAZqS/tbMkzU73yqXdhCLp6pL9M1sdu7XMIFubA3ycbEnJ0vuOBQ4DtgXGAz9vmZQSOB/YHxgLHJ7OBTgTOCci/oOsi9ukVD4JWJbKz0nnmZnVn4IGNkbEzIgYFxHbR8QhEbGszEj2B8aQDWb8KNkg9o/mvbijN5QxJfut1z6paPr6iHgsIp5o49AE4MqIWBkR/wTmAbukbV5EPJW6wl0JTFDWBeHDZHWFAJcCh5Tc69K0fw2wt1q6LJiZ1YvIennl2aoeypsj5l+nC2P0O0ooHd2kWpMAbAU8U/J5QSprr3wz4KWIWNOqfK17pePL0/nrkHSMpOmSpr/wwgsFfRUzs5zqZLZhSQdLehL4J3A3MB+4Oe/1HfXy2kDSe8mSzsC0r7QNzBHYbcCWbRw6NSKuzxtgd0jd7qYAjBs3bj2YJNrMepI6WuvkdGBX4LaIeK+kvchW6c2lo4TyHHB2G/stnzsUEfvkDaLEQmBEyefhqYx2ypcAgyX1SW8hpee33GuBpD7AJnhhMDOrR/WTUFZHxBJJDZIaIuJOST/Je3FHI+X3LCS88twA/EbS2cBbydpxHiB7KxojaTRZojgMOCIiQtKdZIt+XUk2CPP6kntNBP6Wjt/R1mSXZmY1VV+LZ70kaRBZh6nLJS0Gco+072g9lA92dGFE3NPR8Y5I+hjwU7LG/RslzYyI/SJibupd9iiwBjg+IprSNV8GbgEagakRMTfd7hvAlWnOsYeBi1L5RcCvJc0DlpIlITOzuiLqqsprAlmD/FfI1kLZBMg17Qp0XOX19TbKAtierCqpMX+MrW4ScR1wXTvHzgDOaKP8JuCmNsqfIusF1rp8BfDJrsZoZtZd6iWhlMz71SzpRmBJOTU7HVV5rdX3OM2R/y2y9pMT2rzIzMzKV+OEImlX4IdktTmnk63YOBRokPS5iPhTnvt0OpeXpL3JJhcL4PsRMa3LUZuZ2bpq/4byM+CbZFVcdwD7R8R9kt4JXAFUllAkHQicSjZ+41sRcW/FIZuZ2drKm224WvpExK0Akk6LiPsAIuLxcsaDd/SG8geygYJLgJMlnVx6MCIOLjtkMzNbV+0TSuk4/NYr8lbehgLsVVY4ZmbWJd0xrUon3iPpZdLA9bRP+jwg7006apS/u/SzpL7AdsDCiFhcfrxmZtaWWld5RUSXe+2W6mi24QskbZv2NwEeAS4DHpZ0eBEPNzPr9fLO41X7arFOdTQ55AdKBg8eBfw9It4N7ASc3P5lZmZWlh6SUDpqQ1lVsr8v8FvIVgXzLPBmZsWos5HyFekoobwk6SCyubN2Jy1clSZa7HS2YTMzy0fNPSOjdJRQjgXOI5uC/qS0XjFk6xTfWO3AzMx6hfWkOiuPjnp5/Z1sGd7W5beQTdJoZmYF6ClVXh01yq9D0kPVCsTMrNfqBY3ybXFrvJlZwXrlGwpuOzEzK16BbyiSGiU9LOmPVYm1A50mFElntuxHxLdal5mZWQUim3olz5bTicBj1Qu4fXneUPZto2z/ogMxM+uNWsah5Nk6vZc0HDgQuLDKYbepo+nrvwQcB2wjaVbJoY2Av1Q7MDOzXiP/ooid+QnZTCYbFXXDcnTUKP8b4GbgB8DkkvJXImJpVaMyM+tFymiUHyppesnnKRExBSANRF8cETMk7VlshPl0NA5lOdniWp4I0sysWsrrEvxiRIxr59juwMGSDiCbcn5jSf8XEUdWHmQ+5fbyMjOzghXRKB8Rp0TE8IgYBRwG3NGdyQTKH4diZmYFq4MFtgrhhGJmVktBkY3y2S0j7gLuKvSmOTih1MiK17PVAQYM7FfjSMys1nrKSHknlG727DNL+fF3r+OxWQsAePeOW/PVbx/CW4YNrnFkZlYzPSShuFG+G614fRUnHXUhc2c+Q1NTM01NzcyaMZ+Tjr6Q1avX1Do8M6uBIgc21poTSje6Z9pcVq5YRZTUlzY3B6/9eyX33f1EDSMzs5qJQM35tnrnKq9u9OyCpax4ffU65atWrmHRwmU1iMjM6kL954pc/IbSjd72jmEM3GDdRvh+/fuwzZgtaxCRmdUDV3lZ2Xb74DvYbPON6dO38Y2yvn0beeuIIey46zY1jMzMaiaA5si31TknlG7Up28jP7nkPxk/YUc22mQgGw/egAMP3Zn//dXRNDT4fwqzXquXrthoFdpo44GccMpBnHDKQbUOxczqxPpQnZVHTf6zWNInJc2V1CxpXEn5KEmvS5qZtgtKju0kabakeZLOk6RUPkTSNElPpp+bpnKl8+ZJmiVpx+7/pmZmnespvbxqVc8yB/g4cE8bx/4RETuk7Ysl5b8AvgCMSdv4VD4ZuD0ixgC38+ZU+/uXnHtMut7MrL7kre6q/3xSm4QSEY9FRO6BF5KGARtHxH2RDeK4DDgkHZ4AXJr2L21Vfllk7gMGp/uYmdWNbGBj5NrqXT22BI+W9LCkuyV9IJVtBSwoOWdBKgPYIiIWpf3ngC1KrnmmnWvMzOpHc86tzlWtUV7SbUBbgytOjYjr27lsETAyIpZI2gn4vaRt8z4zIkIqv3lL0jFk1WKMHDmy3MvNzCqyPrx95FG1hBIR+3ThmpXAyrQ/Q9I/gLcDC4HhJacOT2UAz0saFhGLUpXW4lS+EBjRzjWtnzsFmAIwbty4nvG/rJmtH9aT9pE86qrKS9LmkhrT/jZkDepPpSqtlyXtmnp3fQ5oecu5AZiY9ie2Kv9c6u21K7C8pGrMzKxOeC6vikj6GPBTYHPgRkkzI2I/4IPAaZJWk9UYfjEilqbLjgMuAQYCN6cN4IfA1ZImAU8Dn0rlNwEHAPOA14Cjqv29zMy6xFVeXRcR1wHXtVF+LXBtO9dMB7Zro3wJsHcb5QEcX3GwZmbVFF4C2MzMiuI3FDMzK0TPyCdOKGZmtabmnlHnVVe9vMzMep2gkIGNkkZIulPSo2muxBOrGXZb/IZiZlZDorBpVdYAX42IhyRtBMyQNC0iHi3i5nk4oZiZ1VoBCSWNs1uU9l+R9BjZdFNOKGZmvUbBvbwkjQLeC9xf6I074YRiZlZLLW0o+QyVNL3k85Q0ddQbJA0iG893UkS8XEiMOTmhmJnVWBm9vF6MiHHtHZTUlyyZXB4RvysitnI4oZiZ1VQUUuWV5jm8CHgsIs6u+IZd4G7DZma1FGQJJc/Wsd2BzwIfLllG/YCqx1/CbyhmZrVWwLjGiLiXbAHImnFCMTOrMS+wZWZmxXBCMTOzikVAU8+Yy8sJxcys1vyGYmZmhXBCMTOzigWwHqwXn4cTiplZTQWE21DMzKxSgRvlzcysIG5DMTOzQjihmJlZ5YqZHLIeOKGYmdVSAPmnr69rTihmZrXmNxQzM6ucp14xM7MiBITHoZiZWSE8Ut7MzArhNhQzM6tYhHt2EQlAAAAJyElEQVR5mZlZQfyGYmZmlQuiqanWQRTCCcXMrJZ60PT1DbV4qKSzJD0uaZak6yQNLjl2iqR5kp6QtF9J+fhUNk/S5JLy0ZLuT+VXSeqXyvunz/PS8VHd+R3NzHKL5nxbnatJQgGmAdtFxPbA34FTACSNBQ4DtgXGAz+X1CipETgf2B8YCxyezgU4EzgnIv4DWAZMSuWTgGWp/Jx0nplZXQkgmiPXVu9qklAi4taIWJM+3gcMT/sTgCsjYmVE/BOYB+yStnkR8VRErAKuBCZIEvBh4Jp0/aXAISX3ujTtXwPsnc43M6sfEX5DKdDRwM1pfyvgmZJjC1JZe+WbAS+VJKeW8rXulY4vT+ebmdWVaGrKtdW7qjXKS7oN2LKNQ6dGxPXpnFOBNcDl1YojD0nHAMekj/+W9EQVHjMUeLEK960mx1x961u84JhLbV3pDV5h2S23xTVDc55e1//uVUsoEbFPR8clfR44CNg74o1O2AuBESWnDU9ltFO+BBgsqU96Cyk9v+VeCyT1ATZJ57cV6xRgSr5v1jWSpkfEuGo+o2iOufrWt3jBMRctIsbXOoai1KqX13jgZODgiHit5NANwGGph9ZoYAzwAPAgMCb16OpH1nB/Q0pEdwKHpusnAteX3Gti2j8UuKMkcZmZWcFqNQ7lZ0B/YFpqJ78vIr4YEXMlXQ08SlYVdnxENAFI+jJwC9AITI2Iuele3wCulPQ94GHgolR+EfBrSfOApWRJyMzMqqQmCSV15W3v2BnAGW2U3wTc1Eb5U2S9wFqXrwA+WVmkhapqlVqVOObqW9/iBcds7ZBrgczMrAj10G3YzMx6ACeUbtDetDHd9OypkhZLmlNSNkTSNElPpp+bpnJJOi/FOUvSjiXXTEznPylpYkn5TpJmp2vOK2LwqKQRku6U9KikuZJOrOe4JQ2Q9ICkR1K8303lZU8LVO7UQ5VKM1E8LOmP60PMkuan/91mSpqeyury96JXighvVdzIOhH8A9gG6Ac8Aoztxud/ENgRmFNS9iNgctqfDJyZ9g8gG2QqYFfg/lQ+BHgq/dw07W+ajj2QzlW6dv8CYh4G7Jj2NyKbnmdsvcad7jEo7fcF7k/3vho4LJVfAHwp7R8HXJD2DwOuSvtj0+9Hf2B0+r1prObvEPD/gN8Af0yf6zpmYD4wtFVZXf5e9MbNbyjV1+a0Md318Ii4h6yXW6nSaWlaT1dzWWTuIxvjMwzYD5gWEUsjYhnZXGzj07GNI+K+yP6/8bKSe1US86KIeCjtvwI8RjbzQV3GnZ777/Sxb9qC8qcFKmvqoa7G20LScOBA4ML0uStTGXVrzO2oy9+L3sgJpframzamlraIiEVp/zlgi7Rf7tQ3W6X91uWFSVUr7yX7r/66jTtVHc0EFpP9gfoH5U8LVO73qNRPyMaDtUwS1ZWpjLo75gBulTRD2QwXUMe/F72N10Pp5SIiJNVlVz9Jg4BrgZMi4uXS6ux6izuy8VI7KFuK4TrgnTUOqUOSDgIWR8QMSXvWOp4y7BERCyW9hWwc2+OlB+vt96K38RtK9XU0nUytPJ9e70k/F6fy9mLtqHx4G+UVk9SXLJlcHhG/W1/ijoiXyGZv2I00LVAbz3gjLq09LVC536MSuwMHS5pPVh31YeDcOo+ZiFiYfi4mS9y7sB78XvQatW7E6ekb2VvgU2QNli2Nk9t2cwyjWLtR/izWbsT8Udo/kLUbMR9I5UOAf5I1YG6a9oekY60bMQ8oIF6R1V//pFV5XcYNbA4MTvsDgT+TzVP3W9Zu4D4u7R/P2g3cV6f9bVm7gfspssbtqv4OAXvyZqN83cYMbAhsVLL/V7J1k+ry96I3bjUPoDdsZL1N/k5Wr35qNz/7CmARsJqsTngSWd337cCTwG0l/88ksoXM/gHMBsaV3OdosgbXecBRJeXjgDnpmp+RBstWGPMeZHXls4CZaTugXuMGtieb9mdWuuf/pPJt0h+oeekPdf9UPiB9npeOb1Nyr1NTTE9Q0sOomr9DrJ1Q6jbmFNsjaZvbcs96/b3ojZtHypuZWSHchmJmZoVwQjEzs0I4oZiZWSGcUMzMrBBOKGZmVggnFKs6SYMlHdfB8XdIuivNIPuYpCmpfE9JIemjJef+sWVkd7rmiXTdTEnXtHP//SVNVzZ78cOSflzwV+x2kk6StEE7x76cZssNSUO7OzbrvZxQrDsMJputtj3nAedExA4R8S7gpyXHFpCNc2jPZ9J1O0TEoa0PStqObDzBkRExlmycwbyyv0H9OQloM6EAfwH2AZ7uvnDMnFCse/wQeFt6izirjePDKJmULyJmlxx7BFguad8uPvtk4IyIeDzduykifgHZxJOS7khrZdwuaWQqv0TSLyTdJ+mp9KY0Nb09XdJyY0n/lnSOsjVQbpe0eSrfIV07S9J1Jetz3CXpTGVrp/xd0gdSeaOksyQ9mK45NpXvma65RtLjki5Pa3z8F/BW4E5Jd7b+whHxcETM7+K/l1mXOaFYd5gM/CO9RXy9jePnAHdIulnSV9IEi6XOAL7Vzr0vL6nyaitZbQfMaOfanwKXRsT2wOVkb0otNiWbj+srwA0pxm2Bd0vaIZ2zITA9IrYF7ga+ncovA76R7ju7pBygT0TsQvaG0VI+CVgeETsDOwNfkDQ6HXtvOncs2Ujx3SPiPOBZYK+I2Kud72bW7ZxQrOYi4mLgXWRTe+wJ3Cepf8nxewAk7dHG5aVVXm0lq47sRra4FMCvyaZ8afGHyKaRmA08HxGzI6KZbMqPUemcZuCqtP9/wB6SNiGb1+vuVH4p2SJnLVomupxRcp+PAJ9L09/fTzaVyJh07IGIWJCePbPkGrO644Ri3U7SGS1vFS1lEfFsREyNiAnAGrI3i1IdvaV0ZC6wUxeuW5l+Npfst3xub9mHPPMYtdyrqeQ+Ak4oSYyjI+LWVue3vsas7jihWHd4hWwpXwAi4tSWP57wxtrjfdP+lmT/hb7WtOHpD+ymZBMxluMs4JuS3p7u3yDpi+nYX8lmzgX4DNksweVoAFo6AhwB3BsRy4FlLe0jwGfJqsM6cgvwpZJ/g7dL2rCTa9b6NzWrB04oVnURsQT4i6Q57bRzfASYI+kRsj+uX4+I59o47wzWXscC1m5Dua2NZ88ia4O4QtJjZDPJbpMOnwAcJWkW2R/+E8v8aq8Cu0iaQ7aeyGmpfCJwVrrvDiXl7bkQeBR4KN3rl3T+JjIF+FNbjfKS/kvSArL1PGZJujDvFzKrhGcbNusiSf+OiEG1jsOsXvgNxczMCuE3FDMzK4TfUMzMrBBOKGZmVggnFDMzK4QTipmZFcIJxczMCuGEYmZmhfj/HH+RUFw2ol4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11053a9b0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Get the index of the maximum band gap material\n",
+    "max_bg_index = np.argmax(coordinates_and_bg, axis=0)[2]\n",
+    "print(\"Maximum band gap material:\")\n",
+    "print(\"{}, Band gap: {}, URL: https://citrination.com/pif/{}\"\n",
+    "      .format(gap_projection.tags[max_bg_index], \n",
+    "              gap_projection.responses[max_bg_index],\n",
+    "              gap_projection.uids[max_bg_index])\n",
+    "     )\n",
+    "print(\"Similar materials:\")\n",
+    "for idx in find_most_similar_materials(max_bg_index, coordinates_and_bg[:,0:2]):\n",
+    "    print(\"{}, Band gap: {}, URL: https://citrination.com/pif/{}\"\n",
+    "          .format(gap_projection.tags[idx],\n",
+    "                  gap_projection.responses[idx],\n",
+    "                  gap_projection.uids[idx])\n",
+    "         )\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.scatter(gap_projection.xs, gap_projection.ys, c=gap_projection.responses)\n",
+    "plt.colorbar(label=\"Band gap (eV)\")\n",
+    "plt.scatter(coordinates_and_bg[max_bg_index, 0], coordinates_and_bg[max_bg_index, 1],\n",
+    "            marker=\"*\", c=\"r\", s=200)\n",
+    "plt.xlabel(\"t-SNE Component 1\")\n",
+    "plt.ylabel(\"t-SNE Component 2\")\n",
+    "#plt.axes().set_aspect('equal', 'datalim')\n",
+    "print(min(gap_projection.xs), max(gap_projection.xs), min(gap_projection.ys), max(gap_projection.ys))\n",
+    "plt.xlim(-5000,55000)\n",
+    "plt.ylim(-20000,6000)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's figure out what material the outlier point with the largest y-value corresponds to"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outlier material (point with the highest y-value):\n",
+      "La2S3, Polycrystalline, Band gap: 1.32, URL: https://citrination.com/pif/1160/3/029F203BCD1C63011185C262945FD909\n",
+      "-651.6577729506878 49984.637839736446 -13976.535209245418 573.5589153283767\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/seto/anaconda2/envs/tensorflow36/lib/python3.6/site-packages/matplotlib/cbook/deprecation.py:106: MatplotlibDeprecationWarning: Adding an axes using the same arguments as a previous axes currently reuses the earlier instance.  In a future version, a new instance will always be created and returned.  Meanwhile, this warning can be suppressed, and the future behavior ensured, by passing a unique label to each axes instance.\n",
+      "  warnings.warn(message, mplDeprecation, stacklevel=1)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEKCAYAAAA1qaOTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3XmcHWWZ9vHflc7KmmACsiQmaFwAWbSNKM4IsoXNOC6IDkMUXkFBFGZeEURFQRTkVRQXNEJkEVlEHUBBiKyjEiBhS8KaYZFEIJBAAhKSTvf9/lFPw+mm+5zq7jpdp7uvr5/6dNVT233Cse+uejZFBGZmZn01rOwAzMxscHBCMTOzQjihmJlZIZxQzMysEE4oZmZWCCcUMzMrhBOKmZkVwgnFzMwK4YRiZmaFGF52AI1m/PjxMXny5LLDMLMBYP78+c9GxIS+XGPv3daP5Staa9/r3jXXRsT0vtyr3pxQOpk8eTLz5s0rOwwzGwAkPd7Xayxf0crt106qeVzT5g+P7+u96s0JxcysRAG00VZ2GIVwQjEzK1EQtETtV14DgSvlzcxK1pbjf3lImi1pmaSFXez7L0khqW6vzpxQzMxKFAStUXvJ6TzgNRX3kiYCewF/Ly7y13JCMTMrWRtRc8kjIm4BVnSx60zgOMh5oV5yHYqZWYkCaK3j73lJM4ClEXGPpLrdB5xQzMxKl/MJZLykyj4NsyJiVrUTJK0HfIXsdVfdOaGYmZUogJZ8dSTPRkRzDy//RmAK0P50shVwp6RpEfFUD69VkxOKmVmJgqjbK6+IWABs2r4t6TGgOSKercf9XClvZlamgNYcSx6SLgZuBd4iaYmkw+oZemd+QjEzK1HWU76ga0V8osb+yQXdqktOKGZmpRKt1Lf1VX9xQjEzK1FWKe+EYmZmfZT1Q3FCMTOzArT5CcXMzPrKTyhmZlaIQLQOkh4cTihmZiXzKy8zM+uzQKyNprLDKIQTiplZibKOjX7lZWZmBXClvJmZ9VmEaA0/oZiZWQHa/IRiZmZ9lVXKD45fxYPjU5iZDVCulDczs8K0uh+KmZn1lXvKm5lZYdoGSSuvUj+FpNmSlklaWFG2iaQ5kh5OP8elckk6S9JiSfdKekfFOTPT8Q9LmllR/k5JC9I5Z0kaHM+VZjZoZINDDqu5DARlR3keML1T2fHA9RExFbg+bQPsA0xNy+HA2ZAlIOAk4N3ANOCk9iSUjvlMxXmd72VmVqpAtERTzWUgKDWhRMQtwIpOxTOA89P6+cCHKsoviMxcYKykzYG9gTkRsSIingPmANPTvo0iYm5EBHBBxbXMzBpCBLTGsJrLQNCIdSibRcSTaf0pYLO0viXwRMVxS1JZtfIlXZS/hqTDyZ56mDRpUh/DNzPrCQ2ajo0NnfbSk0X0w31mRURzRDRPmDCh3rczM3tFUNwTSjf10mdIeiDVPf9e0th6fZZGTChPp9dVpJ/LUvlSYGLFcVulsmrlW3VRbmbWUAqslD+P19YVzwG2i4jtgYeAE4qLvKNGTChXAu0ttWYCV1SUH5Jae+0MrEyvxq4F9pI0LlXG7wVcm/atkrRzat11SMW1zMwaQiDaovaS61pd1EtHxHURsS5tzqXjH9qFKrUORdLFwK7AeElLyFprnQZcJukw4HHgwHT41cC+wGLgJeDTABGxQtIpwB3puJMjov0f9EiyjD0GuCYtZmYNI4CW/hvL61Dg0npdvNSEEhGf6GbX7l0cG8BR3VxnNjC7i/J5wHZ9idHMrL6Udz6U8ZLmVWzPiohZue8inQisAy7qYYC5NWIrLzOzISPI3VP+2Yho7s09JH0K2B/YPf1xXhdOKGZmJavnjI2SpgPHAe+PiJfqdiOcUMzMShWhwsby6qZe+gRgFDAnjT41NyI+W8gNO3FCMTMrUVYpX8zQKt3US59byMVzcEIxMyuV55Q3M7MCZJXyg2PoFScUM7OSDZTh6WtxQjEzK1F7T/nBwAnFzKxkbX5CMTOzvoqAljYnFDMz66PslZcTipmZFaCePeX7kxOKmVmJ3GzYzMwK4ldeZmZWkMEyp7wTiplZibJWXsWM5VU2JxQzsxK5Y6OZmRXGr7zMzKzP3MrLzMwK41ZeZmbWZxFinROKmZkVwa+8zMyszwZTHUq3z1mSmiQdIekUSbt02vfV+odmZjY0tIVqLgNBtRd3PwfeDywHzpL0/Yp9H65rVGZmQ0R7P5TBnlCmRcQnI+IHwLuBDST9TtIoGCSNps3MGkAbqrnkIWm2pGWSFlaUbSJpjqSH089x9foc1RLKyPaViFgXEYcDdwM3ABvUKyAzs6EkAta1Dau55HQeML1T2fHA9RExFbg+bddFtSjnSeoQWEScDPwSmFyvgMzMhpqiXnlFxC3Aik7FM4Dz0/r5wIeKi7yjblt5RcTB3ZSfA5xTr4DMzArV1gbDGrefRz+M5bVZRDyZ1p8CNqvXjRr3X9nMrK+WL4eJE2FF5z/aG0uEai7AeEnzKpbDe36fCLKWynXhfihmNnhdeSX84x/Zz099quxoupWz0v3ZiGjuxeWflrR5RDwpaXNgWS+ukYufUMxs8DrvvI4/G1BE3fuhXAnMTOszgSv6HHQ3aiYUSdfnKbPqljyxnJtvvI+X16wtOxSzoWHVKmLuXADi1lth1aqSA+qOaG0bVnPJdSXpYuBW4C2Slkg6DDgN2FPSw8Aeabsuun3lJWk0sB7Ze7txvNr3ZCNgy3oFNJi0rG3hb9fdwze/fBkxHNaNG4Na2ghaueGmkxkxwm8czQrx3HPw97+/srnm5RZuPvZ7vK8l+yW2eh0s+OR/Mu1bn0eq+Gt/0iQYV7duGblFQZXyEfGJbnbtXsgNaqj2G+0I4BhgC2A+ryaUVcCP6xzXgPbccy9w4Du+xrCV/6S1Sax91yRa1x8Fw4dBW0AEH9j1a9zyl293/HKbWe+cdhp897swejSMHAkvt7DLulbWi+yNwHpta9numgtZd8MljBjRBGvXwssvw3HHwemnlxr6kBjLKyJ+GBFTgP8bEVtHxJS07BARAyahSJou6UFJiyXVrUNPu4jgo+/6OkHQ1rKGtta18OJqaEpfmGGCpmGs22ITPnLMD+odjtnQ8J3vwLe/DRKsWsWotatZv63j6+X129YyYvU/s1dfUnb8d75TUsAVsr8xay4DQc13LhHxI0nvJevMOLyi/II6xlUISU3AT4A9gSXAHZKujIj76nXP3Wd8m6bnV8GK7H3tMGD0rYtZt+U41uz8puyLnCxbWrfGFmZDy7BhcMIJsPvutB3wQVqeeZZR0fqaw9aqiZGv3xSuuALe9a4SAu1aI0wBnKo59gf+hezN1GpgIfDHiFiU5xo1E4qkC4E3kg270v5fKICGTyjANGBxRDwCIOkSsl6jdUkora2ttD3xAk0rXq38E0BrG8OXPse6Z1bRuunGr+4b8dovvJn1wbRp6KEHWbnZFDZd89xrdv9zg3GMfOAB2GijEoLrWqRK+TJJ+iZwAHAjcBtZ0+LRwJuB01Ky+a+IuLfadfLUCjcD26QOMQPNlsATFdtLyAa6rIu/3PEwwx/v5qmjtY2mJSuyhBKBWtto2dmtts2KplGjGB8vdblv45YXYdSofo6otgb47Xp7RJzUzb7vS9oUmFTrInl+oy0EXt+TyAYaSYe39z595plnen2dLTcbi7prFiygaViWTFpaGbX0WSZssEWv72Vm3Zgzh2Gjs6SxdvhIWtREy/BsrNthI0fCnDllRtelnD3l62m9NJJ8N/HFsoiYV+sieRLKeOA+SddKurJ96UmkJVoKTKzY3iqVdRARsyKiOSKaJ0yY0OubvWnK62mLtq53BrRsORa9tJYN//Y4L+06hquO+EKv72Vm3bjwwqzifb31GPm5Ixix6nlGfPZwGDMmK7/wwrIj7CCrdC89oXwSeELShZL2TfXPPZbnldc3enPhBnEHMFXSFLJEchDZP1zdjJ8ynhUPPp0NSFdh3RvG0zp+I9a/90le3G4CEzffvJ5hmA1Na9fCH/+Y1ZFcdhnsvXdW/qMfwX77wcc/nu1vaYERI8qNtULZzYYj4t8kbQT8G3A0cK6kK4CLI+LmvNep+YSSLvYYMCKt3wHc2auo+1lErAM+D1wL3A9clre1Qm9duugsoq2NGNFEy8RNWLv1pry4x7as3vmNDH9qFS1jR7HFnpty+TGfrWcYZkNTayvMnAkPPfRqMmk3fXpWfsghsG5dOfF1oxGaDUfEqog4PyL2AbYD7iKbrfeJGqe+Is/QK58BLiebEhiyiu7/7kW8pYiIqyPizRHxxog4tT/u+ee237Dfoe+nacVLDH+5ldHL17L+Q88xbNhwDjxsN35z3FH9EYbZ0DNmDPz0p7BZNyO0b7ZZtn/MmP6Nq4pAtLUNq7n0lzQyyoeBjwObkP3+zyXPK6+jyJrf3gYQEQ+nGn+r4tizP8exZ3+Ox/6xnF/8963s8OYtOXCPncoOy8waUNmNvCRtQPa66xPATmQDSp4C3NSTFr55EsqaiFjbPkSIpOGU//kHjMlbvI5Tj9y/7DDMrFFFcWN59cFjwJ+AnwLXRkRLby6SJ6HcLOkrwBhJewJHAlf15mZmZtaF8v9EnxgRqwEkjZG0dUQ82NOL5HkxdzzwDLCAbMDIq4Gv9vRGZmbWtbKbDVckkwPIRkX5U9resSfdRPKM5dUG/CItZmZWoADa2kp/5dXuG2R15jcBRMTdqdtFLnnG8tol3eQN6Xhl94mtex6rmZl1EED5dSjtWiJiZadpNQqtlD8XOJZsThSPZmhmVrAGGMur3SJJnwSaJE0FvgD8Le/JeepQVkbENWksl+XtS2+jNTOzTiLH0j+OBrYF1gC/BlaSTbSYS54nlBslnQH8Lt0EgIgYEL3lzcwaW7+M1ZVLRLwEnJiWHsuTUNqHe2+uvC/wgd7c0MzMOin5lZekXwBnRcSCLvatT9Zrfk1EXFTtOnlaee3W6yjNzKy6gCi/lddPgK9JejvZlCXPkE2wNRXYCJgNVE0mkK+V18bAScC/pqKbgZMjYmXv4jYzs46KSSiSjgX+D9kzzwLg0xHxcq3zIuJu4MA0BEszsDnZFMD396SDY55K+dnAC8CBaVkF/DLvDczMrIYCKuUlbUnWKqs5IrYDmsim7MgfRsSLEXFTRFwcEf/d097yeepQ3hgRH6nY/qaku3tyEzMzq6K4OpThZMNktQDrAf8o7Mo55HlCWS3pfe0bqaPj6vqFZGY2hLR3bKy11LpMxFLg/wF/B54k6/JxXX2D7yjPE8rngPNTXYqAFcDMukZlZjaE5OzYOF5S5bzusyJiVvtGmsdkBjAFeB74jaSDI+JXPY0nzd4YEfFCT87L08rrbmCHdAMiYlVPgzMzsyrytfJ6NiKaq+zfA3g0Ip4BkPQ74L1A7oQi6V1k9eYbZpt6Hjg0IubnOT/PjI2vk3QW2WBhN0r6oaTX5Q3QzMyqU9Recvg7sLOk9ZQNxrU72dTnPXEucGRETI6IN5BNsJi7EVaeOpRLyNokfwT4aFq/tIdBmplZV/K08MqRUCLiNrLpeu8kazI8DJhV9aTXao2I/6m45l+AdXlPzlOHsnlEnFKx/S1JH+9BgGZm1q18le55RMRJZP0Ge+tmST8HLiZLYx8HbpL0jnT9qkNu5Uko10k6CLgsbX8UuLb38ZqZWQeNM9rwDuln56S0EzmG3MqTUD5DNtpke8XOMOCfko4gawWwUf5YzczsNdrKDiDT16G28rTy2rAvNzAzsyoaa4ItJO1HNoT96PayiDg5z7l5nlCQtD0wufL4iPhdj6I0M7Mu5WzFVXeSfkbWw3434ByyKo7b856fZ3DI2cD2wCJefTALsvlRzMysrxokoQDvjYjtJd0bEd+U9D3gmrwn53lC2Tkitul9fGZmNkC0D6v1kqQtgOVkIw/nkqcfyq2SnFDMzOqkoI6NRfiDpLHAGWT9WR4ja0KcS54nlAvIkspTZFMAi6x11/Y9j9XMzDoI8g69UncVfQ5/K+kPwOiezH2VJ6GcC/wHWc/LBmncZmY2iDRIHYqkD3dRthJYEBHLap2fJ6E8ExFX9iY4MzOrrVFaeQGHAe8BbkzbuwLzgSmSTo6IC6udnCeh3CXp18BVZK+8ADcbNjMrTOMklOHA2yLiaQBJm5FVe7wbuAXoc0IZQ5ZI9qooc7NhM7OiNE5CmdieTJJlqWxFmgWyqjw95T/dl+jMzKx7/dyKq5abUmX8b9L2R1LZ+mSTdlWVZz6UrST9XtKytPxW0lZ9i9nMzF7RptpL/2if/2THtFwAHBUR/8wzzleeV16/BH4NfCxtH5zK9uxVuGZm1kGjPKFERAC/TUuP5enYOCEifhkR69JyHjChNzczM7MuFDDBViPIk1CWSzpYUlNaDibrjt9rkj4maZGkNknNnfadIGmxpAcl7V1RPj2VLZZ0fEX5FEm3pfJLJY1M5aPS9uK0f3JfYjYzq4scveQb5QmmljwJ5VDgQOAp4Emy0Sf7WlG/EPgwWTO0V6QhXg4iGzp5OvDT9kQG/ATYB9gG+ETFcDCnA2dGxJuA58jaUZN+PpfKz0zHmZk1nkHyhJKnldfjwAeLvGlE3A8gvaaiaQZwSUSsAR6VtBiYlvYtjohH0nmXADMk3U82g9gn0zHnA98Azk7X+kYqvxz4sSSld4RmZg1DJY9BImkBVdJW3qG2uk0oks4g+yX+807lRwBTIuL4rs/sky2BuRXbS1IZwBOdyt8NvA54PiLWdXH8lu3nRMS6NHzA64BnO99U0uHA4QCTJk0q5IOYmQ0g+6efR6Wf7R0Y/70nF6n2yusDwKwuyn9RcfNuSfqzpIVdLDN6EmB/iIhZEdEcEc0TJri9gZn1s5JfeUXE4+lt1J4RcVxELEjL8XTs1F5VtVdeo7p6PRQRberiXVUXx+2RN4gKS4GJFdtbpTK6KV8OjJU0PD2lVB7ffq0lkoYDG9PHxgRmZoUrsNI9DT1/DrBddmUOjYhbe3YJ7RIRf00b7yVfXTvUOHC1pKld3G0qr07CUrQrgYNSC60pwFSy6SfvAKamFl0jySrur0wJ70ayhgIAM4ErKq41M61/FLjB9Sdm1pCKe0L5IfCniHgrsANwfw8jOYysMdRjkh4HfkrWMCuXak8oXweukfQtstEmAZqBE4BjehhkB5L+DfgRWX+WP0q6OyL2johFki4D7gPWkfXQbE3nfB64FmgCZkfEonS5LwOXpDjvIhtun/TzwlSxv4IsCZmZNZ4C/tSVtDHwr8CnACJiLbC2R2FEzAd2SNeiJ3OhQJWEEhHXSPoQ8CXg6FS8EPhIRCzoyU26uPbvgd93s+9U4NQuyq8Gru6i/BFebQlWWf4yr/buNzNrSKKwVl5TgGeAX0ragexB4IsR8c/csUijyMbvmgwMb6/diIiT85xftdlwRCzk1ddGZmZWtPx1KOMlzavYnhURlQ2nhgPvAI6OiNsk/RA4HvhaD6K5AlhJlozW1Dj2NfKM5WVmZvWUL6E8GxHNVfYvAZZExG1p+3KyhNITW0XE9B6e84rctfdmZlYnBVTKR8RTwBOS3pKKdierj+6Jv0l6ew/PeYWfUMzMSlbgWF1HAxel1rCP0PNhst4HfErSo2SvvEQ2CHGfe8pfFhEHpvXTI+LLFfuui4jcnV3MzKyKghJKRNxN1hq3t/bpy/2rvfKq7IPSee4Tdyc3MytCZK28ai39EsqrPeZX04teMNUSSrWLuIOgmVlRGmS0YUkflPQw8ChwM/AYcE3e86vVoawnaSeypDMmrSstY3odsZmZddBA852cAuwM/DkidpK0G9ksvblUSyhPAd/vYr1923rp5dVreXDRUsasN5Kpb9uiq2H8zWwoaZyE0hIRyyUNkzQsIm6U9IO8J1frKb9rIeFZB9dffQ9nffsqhg0bRltbsPHY9fjWjw5m0hRXS5kNSY01gdbzkjYgm/zwIknLgNw97au18vrXaidGxC3V9ttrPfrw0/zw1KtY83LLK2VrXl7Llz97Pr+6+j9panK3ILOhRjTUK68ZZBXyx5LNhbIxkGvYFaj+yutLXZQFsD3ZsPBN+WM0gD/+9g5a1q7rUBYBq1evYcH8x9hx2tYlRWZmZWqUhFIx7lebpD8Cy3sySnu1V14HVG5L2gX4Kln9ydFdnmRVrVj+Im1tr/1vI8SqlfWaEcDMGl7JCUXSzsBpZCOzn0I2Y+N4YJikQyLiT3muU7OnvKTdyQYXC+DbETGn11EPce95/1uZf+tiXl7d0qG8paWV7Xby1MNmQ1b5Tyg/Br5C9orrBmCfiJgr6a3AxUCuhNLtS3tJ+0n6G/B/ga9GxG5OJn3z/r22Y+LkCYwaPeKVstFjRnDgIbuwyfgNS4zMzEqTRhuutdTZ8Ii4LiJ+AzwVEXMBIuKBHl2kyr6ryEavXA4cJ+m4yp0R8cEeBjzkjRw5nO+dcyjXXXUXN1+3kPU3GM0BH5tG83vfVHZoZlam8p9QKvvid37/3vc6FGC3HoVjuYwaPYIDPjaNAz72mjnBzGyI6q+hVarYQdIqUsf1tE7aHp33ItUq5W+u3JY0gmzi+6URsazn8ZqZWVfKbuUVEYW02q1Wh/IzSdum9Y2Be4ALgLskfaKIm5uZDXl5xvEq/5VYLtV60v1LRCxK658GHoqItwPvBI7r/jQzM+uRQZJQqtWhrK1Y3xP4DWSzgnnsKTOzYjRYT/k+qZZQnpe0P7AU2AU4DEDScDzasJlZYdRFh+eBqFpCOQI4C3g9cEyarxiyeYr/WO/AzMyGhAH0SquWaq28HgKmd1F+LXBtPYMyMxtKBssrrx4NbyvpznoFYmY2ZA2BSvmuuDbezKxgQ/IJBdedmJkVr8AnFElNku6S9IfiA62uZkKRdHr7ekR8tXOZmZn1QWRDr9RaeuCLwP31Cba6PE8oe3ZRtk/RgZiZDUXt/VCKGG1Y0lbAfsA5dQy5W9WmAP4ccCSwtaR7K3ZtCPy13oGZmQ0Z+SdFrOUHZCOZlDIfRrVK+V8D1wDfAY6vKH8hIlbUNSozsyEk5xPIeEnzKrZnRcSsV66RdURfFhHzJe1abIT5VOuHshJYCXggSDOzeslf6f5sRDRX2b8L8EFJ+5INOb+RpF9FxMF9DzKfnrbyMjOzghVRKR8RJ0TEVhExGTgIuKE/kwn0vB+KmZkVrAEm2CqEE4qZWZmCIivls0tG3ATcVOhFcyjllZekMyQ9IOleSb+XNLZi3wmSFkt6UNLeFeXTU9liScdXlE+RdFsqv1TSyFQ+Km0vTvsn9+dnNDPLq6hmw2Urqw5lDrBdRGwPPAScACBpG7J3f9uSDUz509Trswn4CVn/l22AT6RjAU4HzoyINwHPkYbZTz+fS+VnpuPMzBrPIBnLq5SEEhHXRcS6tDkX2CqtzwAuiYg1EfEosBiYlpbFEfFIRKwFLgFmKJvp6wPA5en884EPVVzr/LR+ObC7PDOYmTWYIjs2lq0RWnkdStbfBWBL4ImKfUtSWXflrwOer0hO7eUdrpX2r0zHm5k1jgjUVnsZCOpWKS/pz2STc3V2YkRckY45EVgHXFSvOPKQdDhwOMCkSZPKDMXMhqKBkS9qqltCiYg9qu2X9Clgf2D3iFeaOCwFJlYctlUqo5vy5cBYScPTU0jl8e3XWpKmLd44Hd9VrLOAWQDNzc2D5D+tmQ0UA+WVVi1ltfKaTjbezAcj4qWKXVcCB6UWWlOAqcDtwB3A1NSiayRZxf2VKRHdCHw0nT8TuKLiWjPT+kfJOvkMkv9sZjZoBNAWtZcBoKx+KD8GRgFzUj353Ij4bEQsknQZcB/Zq7CjIqIVQNLnyaYebgJmR8SidK0vA5dI+hZwF3BuKj8XuFDSYmAFWRIyM2s8AyNf1FRKQklNebvbdypwahflVwNXd1H+CFkrsM7lLwMf61ukZmb1N1heebmnvJlZyQZKK65anFDMzMo0gDou1uKEYmZWoqxj4+DIKE4oZmZl82jDZmZWBD+hmJlZ37kOxczMijFwxuqqxQnFzKxsfuVlZmZ9Fp4C2MzMiuInFDMzK8TgyCdOKGZmZVPb4Hjn1QgzNpqZDV1B1rGx1lKDpImSbpR0n6RFkr5Yt5i74ScUM7MSiSiqY+M64L8i4k5JGwLzJc2JiPuKuHgefkIxMytbRO2l5iXiyYi4M62/ANwPbFnnyDvwE4qZWdkKbuUlaTKwE3BboReuwQnFzKxM7XUotY2XNK9ie1ZEzOp8kKQNgN8Cx0TEqkJizMkJxcysZDlbeT0bEc1VryONIEsmF0XE74qIrSecUMzMSpWvjqQWSQLOBe6PiO/3+YK94Ep5M7MyBYVUygO7AP8BfEDS3WnZt66xd+InFDOzshXQrzEi/kI2AWRpnFDMzErmCbbMzKwYTihmZtZnEdA6OMbyckIxMyubn1DMzKwQTihmZtZnAXhOeTMz67uAcB2KmZn1VeBKeTMzK4jrUMzMrBBOKGZm1nfFDA7ZCJxQzMzKFEC+4esbnhOKmVnZ/IRiZmZ956FXzMysCAExSPqhlDLBlqRTJN2bJoC5TtIWqVySzpK0OO1/R8U5MyU9nJaZFeXvlLQgnXNWmrUMSZtImpOOnyNpXP9/UjOzHNqi9jIAlDVj4xkRsX1E7Aj8Afh6Kt8HmJqWw4GzIUsOwEnAu4FpwEkVCeJs4DMV501P5ccD10fEVOD6tG1m1niKmbGxdKUklIhYVbG5Plk7B4AZwAWRmQuMlbQ5sDcwJyJWRMRzwBxgetq3UUTMjYgALgA+VHGt89P6+RXlZmaNIyJr5VVrGQBKq0ORdCpwCLAS2C0Vbwk8UXHYklRWrXxJF+UAm0XEk2n9KWCzIuM3MyvMAHkCqaVuTyiS/ixpYRfLDICIODEiJgIXAZ+vVxzpXsGrT0FdxXq4pHmS5j3zzDP1DMXMrJMgWltrLgNB3Z5QImKPnIdeBFxNVkeyFJhYsW+rVLYU2LVT+U2pfKsujgd4WtLmEfFkejW2rEqss4BZAM3NzYPjTwUzGxgG0fD1ZbXymlqxOQN4IK1fCRySWnvtDKxMr62uBfaSNC5Vxu8FXJv2rZK0c2rddQhwRcW12luDzawoNzNrLNFWexkAyqoKWu0gAAAIQElEQVRDOU3SW4A24HHgs6n8amBfYDHwEvBpgIhYIekU4I503MkRsSKtHwmcB4wBrkkLwGnAZZIOS/c4sJ4fyMysNwKIQfKEUkpCiYiPdFMewFHd7JsNzO6ifB6wXRfly4Hd+xapmVmdhSfYMjOzggyUSvdaFIOkuVpRJD1D9oqsaOOBZ+tw3XpyzPU30OKFgRdzPeN9Q0RM6MsFJP2JLMZano2I6bUPK48TSj+RNC8imsuOoyccc/0NtHhh4MU80OIdyMoaesXMzAYZJxQzMyuEE0r/mVV2AL3gmOtvoMULAy/mgRbvgOU6FDMzK4SfUMzMrBBOKP1A0nRJD6ZJwPp1XhZJsyUtk7SwoqzLyceKnOCsjzFPlHSjpPskLZL0xUaOW9JoSbdLuifF+81UPkXSbekel0oamcpHpe3Faf/kimudkMoflLR3RXldvkOSmiTdJekPAyFmSY+l/253S5qXyhryezEkRYSXOi5AE/C/wNbASOAeYJt+vP+/Au8AFlaUfRc4Pq0fD5ye1vclG7pGwM7Abal8E+CR9HNcWh+X9t2ejlU6d58CYt4ceEda3xB4CNimUeNO19ggrY8AbkvXvgw4KJX/DPhcWj8S+FlaPwi4NK1vk74fo4Ap6XvTVM/vEPCfwK+BP6Ttho4ZeAwY36msIb8XQ3HxE0r9TQMWR8QjEbEWuIRsQMx+ERG3ACs6FXc3+ViRE5z1JeYnI+LOtP4CcD/ZPDcNGXe674tpc0RaAvgAcHk38bZ/jsuB3dNfwjOASyJiTUQ8Sjam3TTq9B2StBWwH3BO2lajx9yNhvxeDEVOKPXX3eRgZepu8rEiJzgrRHq1shPZX/0NG3d6dXQ32TQJc8j+On8+ItZ1cY9X4kr7VwKv68Xn6KsfAMeRDdJKiqHRYw7gOknzJR2eyhr2ezHUeCyvIS4iQlJDNvWTtAHwW+CYiFhV+Tq70eKOiFZgR0ljgd8Dby05pKok7Q8si4j5knYtO54eeF9ELJW0KTBH0gOVOxvtezHU+Aml/rqbNKxMT6fHe9Rx8rFqE5x1V97dBGd9ImkEWTK5KCJ+N1DijojngRuB95C9Ymn/o63yHq/ElfZvDCzvxefoi12AD0p6jOx11AeAHzZ4zETE0vRzGVninsYA+F4MGWVX4gz2hewp8BGyCsv2yslt+zmGyXSslD+DjpWY303r+9GxEvP2VL4J8ChZBea4tL5J2te5EnPfAuIV2fvrH3Qqb8i4gQnA2LQ+BvgfYH/gN3Ss4D4yrR9Fxwruy9L6tnSs4H6ErHK7rt8hstlQ2yvlGzZmYH1gw4r1vwHTG/V7MRSX0gMYCgtZa5OHyN6rn9jP974YeBJoIXsnfBjZu+/rgYeBP1f8n0nAT1KcC4DmiuscSlbhuhj4dEV5M7AwnfNjUmfZPsb8PrJ35fcCd6dl30aNG9geuCvFuxD4eirfOv2CWpx+UY9K5aPT9uK0f+uKa52YYnqQihZG9fwO0TGhNGzMKbZ70rKo/ZqN+r0Yiot7ypuZWSFch2JmZoVwQjEzs0I4oZiZWSGcUMzMrBBOKGZmVggnFKs7SWMlHVll/1sk3ZRGkL1f0qxUvqukkHRAxbF/aO/Znc55MJ13t6TLu7n+PpLmKRu9+C5J3yv4I/Y7ScdIWq+bfZ9Po+WGpPH9HZsNXU4o1h/Gko1W252zgDMjYseIeBvwo4p9S8j6OXTn39N5O0bERzvvlLQdWX+CgyNiG7J+Bot7/AkazzFAlwkF+CuwB/B4/4Vj5oRi/eM04I3pKeKMLvZvTsWgfBGxoGLfPcBKSXv28t7HAadGxAPp2q0RcTZkA09KuiHNlXG9pEmp/DxJZ0uaK+mR9KQ0Oz09ndd+YUkvSjpT2Rwo10uakMp3TOfeK+n3FfNz3CTpdGVzpzwk6V9SeZOkMyTdkc45IpXvms65XNIDki5Kc3x8AdgCuFHSjZ0/cETcFRGP9fLfy6zXnFCsPxwP/G96ivhSF/vPBG6QdI2kY9MAi5VOBb7azbUvqnjl1VWy2g6Y3825PwLOj4jtgYvInpTajSMbj+tY4MoU47bA2yXtmI5ZH5gXEdsCNwMnpfILgC+n6y6oKAcYHhHTyJ4w2ssPA1ZGxLuAdwGfkTQl7dspHbsNWU/xXSLiLOAfwG4RsVs3n82s3zmhWOki4pfA28iG9tgVmCtpVMX+WwAkva+L0ytfeXWVrKp5D9nkUgAXkg350u6qyIaRWAA8HRELIqKNbMiPyemYNuDStP4r4H2SNiYb1+vmVH4+2SRn7doHupxfcZ29gEPS8Pe3kQ0lMjXtuz0ilqR7311xjlnDcUKxfifp1PanivayiPhHRMyOiBnAOrIni0rVnlKqWQS8sxfnrUk/2yrW27e7m/YhzzhG7ddqrbiOgKMrEuOUiLiu0/GdzzFrOE4o1h9eIJvKF4CIOLH9lye8Mvf4iLT+erK/0DsMG55+wY4jG4ixJ84AviLpzen6wyR9Nu37G9nIuQD/TjZKcE8MA9obAnwS+EtErASea68fAf6D7HVYNdcCn6v4N3izpPVrnNPh39SsETihWN1FxHLgr5IWdlPPsRewUNI9ZL9cvxQRT3Vx3Kl0nMcCOtah/LmLe99LVgdxsaT7yUaS3TrtPhr4tKR7yX7xf7GHH+2fwDRJC8nmEzk5lc8EzkjX3bGivDvnAPcBd6Zr/ZzaTyKzgD91VSkv6QuSlpDN53GvpHPyfiCzvvBow2a9JOnFiNig7DjMGoWfUMzMrBB+QjEzs0L4CcXMzArhhGJmZoVwQjEzs0I4oZiZWSGcUMzMrBBOKGZmVoj/DzoAj+76pwIoAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x111141160>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "outlier_index = np.argmax(coordinates_and_bg, axis=0)[1]\n",
+    "print(\"Outlier material (point with the highest y-value):\")\n",
+    "print(\"{}, Band gap: {}, URL: https://citrination.com/pif/{}\"\n",
+    "      .format(gap_projection.tags[outlier_index],\n",
+    "              gap_projection.responses[outlier_index],\n",
+    "              gap_projection.uids[outlier_index])\n",
+    "     )\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.scatter(gap_projection.xs, gap_projection.ys, c=gap_projection.responses)\n",
+    "plt.colorbar(label=\"Band gap (eV)\")\n",
+    "plt.scatter(coordinates_and_bg[outlier_index, 0], coordinates_and_bg[outlier_index, 1],\n",
+    "            marker=\"*\", c=\"r\", s=200)\n",
+    "plt.xlabel(\"t-SNE Component 1\")\n",
+    "plt.ylabel(\"t-SNE Component 2\")\n",
+    "print(min(gap_projection.xs), max(gap_projection.xs), min(gap_projection.ys), max(gap_projection.ys))\n",
+    "plt.xlim(-5000,55000)\n",
+    "plt.ylim(-20000,6000)\n",
+    "plt.axes().set_aspect('equal', 'datalim')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also find materials that are similar to a given material in the dataset. Let's find materials similar to Cr3Se4 https://citrination.com/datasets/1160/version/3/pif/0478C7E0B7C4F75C6081EC5184522704. The uid comes in the format dataset_id/version/pif_id. For Cr3Se4, the uid is 1160/3/0478C7E0B7C4F75C6081EC5184522704."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cr3Se4, Band gap: 0.015, URL: https://citrination.com/pif/1160/3/0478C7E0B7C4F75C6081EC5184522704\n",
+      "Similar materials:\n",
+      "Cr2Se3, Band gap: 0.15, URL: https://citrination.com/pif/1160/3/B02503AE0620DB98FC19B2637224AAEC\n",
+      "Mn1Se1, Single crystalline, Band gap: 1.8, URL: https://citrination.com/pif/1160/3/57C264FAE60E73465FA484FCC686CFD8\n",
+      "Ru1Se2, Polycrystalline, Band gap: 1.0, URL: https://citrination.com/pif/1160/3/EB7F89526BB12CD5DB57956267A4B814\n",
+      "Fe1Se2, Polycrystalline, Band gap: 0.5, URL: https://citrination.com/pif/1160/3/5FE698B58A042D23AA8B6EF0CB7C4923\n",
+      "Rh1Se3, Band gap: 0.7, URL: https://citrination.com/pif/1160/3/30EEC951791B144F58B004220982F02B\n",
+      "Rh1Se2, Band gap: 0.6, URL: https://citrination.com/pif/1160/3/53AE437CD930A984FD4C45C29F2F1B5F\n",
+      "Ru1P2, Polycrystalline, Band gap: 1.0, URL: https://citrination.com/pif/1160/3/532047FC884C8662B6F01D9759035CF6\n",
+      "Rh2S3, Band gap: 0.8, URL: https://citrination.com/pif/1160/3/5663B427D1ADBB8DBA1B8B503E394785\n",
+      "W1S2, Single crystalline, Band gap: 0.45, URL: https://citrination.com/pif/1160/3/C685CC068EAA30FF9DD3C8F27E77C42C\n",
+      "Mn1Se2, Polycrystalline, Band gap: 0.2, URL: https://citrination.com/pif/1160/3/FC26DD83901588E628E6F0FFE5878CCA\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/seto/anaconda2/envs/tensorflow36/lib/python3.6/site-packages/matplotlib/cbook/deprecation.py:106: MatplotlibDeprecationWarning: Adding an axes using the same arguments as a previous axes currently reuses the earlier instance.  In a future version, a new instance will always be created and returned.  Meanwhile, this warning can be suppressed, and the future behavior ensured, by passing a unique label to each axes instance.\n",
+      "  warnings.warn(message, mplDeprecation, stacklevel=1)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEKCAYAAAA1qaOTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3XmcHGWdx/HPNwcJ4YYgIiEmuPEARNCRVfHgJogIKiIoEpEVFEVxd0UQd1lBdmVxRRFRsxIIyCnCgtwRObwIJoAkgEDkkEQwkEA4DDlmfvtHPR16hpnu6pnqqe6Z79tXvabqqa6q30A7P556LkUEZmZmAzWi7ADMzGxocEIxM7NCOKGYmVkhnFDMzKwQTihmZlYIJxQzMyuEE4qZmRXCCcXMzArhhGJmZoUYVXYArWb8+PExadKkssMwszYwd+7cpyNi04HcY69d1oklSzvrP+ueFTdExNSBPKvZnFB6mDRpEnPmzCk7DDNrA5IeG+g9lizt5I4bJtb93MjNHxo/0Gc1mxOKmVmJAuiiq+wwCuGEYmZWoiBYFfVfebUDN8qbmZWsK8f/8pA0Q9JiSfN7OfcvkkJS016dOaGYmZUoCDqj/pbTucArGu4lbQnsCfyluMhfyQnFzKxkXUTdLY+IuA1Y2sup04FjIeeN+sltKGZmJQqgs4l/5yXtByyKiD9KatpzwAnFzKx0OWsg4yVVj2mYHhHTa10gaRzwNbLXXU3nhGJmVqIAVuVrI3k6IjoavP3rgMlApXYyAbhT0o4R8WSD96rLCcXMrERBNO2VV0TMA15VOZb0KNAREU8343lulDczK1NAZ44tD0kXAb8H3iBpoaTDmxl6T66hmJmVKBspX9C9Ig6uc35SQY/qlROKmVmpRCfN7X01WJxQzMxKlDXKO6GYmdkAZeNQnFDMzKwAXa6hmJnZQLmGYmZmhQhE5xAZweGEYmZWMr/yMjOzAQvEyhhZdhiFcEIxMytRNrDRr7zMzKwAbpQ3M7MBixCd4RqKmZkVoMs1FDMzG6isUX5o/CkeGr+FmVmbGkqN8qX+FpJmSFosaX5V2caSZkl6KP3cKJVL0hmSFki6R9Jbq66Zlj7/kKRpVeVvkzQvXXOGmr2gsplZP3SG6m7toOy0eC4wtUfZccBNETEFuCkdA+wNTEnbEcAPIUtAwInAPwI7AidWklD6zGeqruv5LDOzUlVGytfb2kGpUUbEbcDSHsX7ATPT/kxg/6ry8yJzO7ChpM2BvYBZEbE0Ip4BZgFT07n1I+L2iAjgvKp7mZm1jK4YUXdrB63YhrJZRDyR9p8ENkv7WwCPV31uYSqrVb6wl/JXkHQEWa2HiRMnDjB8M7P8sskh2yNh1NPSv0WqWeRcTXlAz5keER0R0bHppps2+3FmZmsEYlWMrLu1g1ZMKH9Lr6tIPxen8kXAllWfm5DKapVP6KXczKxlREBnjKi7tYNWjPIqoNJTaxpwZVX5oam31zuAZenV2A3AnpI2So3xewI3pHPPSXpH6t11aNW9zMxahOjKsbWDUttQJF0E7AyMl7SQrLfWt4BLJR0OPAYcmD5+LfB+YAHwd+AwgIhYKulk4A/pcydFRKWh/yiynmRrA9elzcysZQQUVgORNAP4ALA4IrZNZacB+wIrgT8Dh0XEs4U8sIdSE0pEHNzHqd16+WwAn+/jPjOAGb2UzwG2HUiMZmbNVmCj/LnAmWS9WitmAcdHxGpJpwLHA18t6oHVWvGVl5nZsBGIrqi/5bpXL0MxIuLGiFidDm+ne9tyoVqx27CZ2bARwKrBm8vr08Alzbq5E4qZWamUdz2U8ZLmVB1Pj4jpuZ8inQCsBi5oMMDcnFDMzEoUkHck/NMR0dGfZ0j6FFlj/W6pPbopnFDMzErWzBUbJU0FjgXeFxF/b9qDcEIxMytVhAqbq6uPoRjHA2OAWWnC9dsj4rOFPLAHJxQzsxJljfLFTK3Sx1CMswu5eQ5OKGZmpfKa8mZmVoCsUb49plapxwnFzKxkQ2X6eicUM7MSVUbKDwVOKGZmJetyDcXMzAYqAlZ1OaGYmdkAZa+8nFDMzKwAzRwpP5icUMzMSuRuw2ZmVhC/8jIzs4K0y5rx9TihmJmVKOvlVcxcXmVzQjEzK5EHNpqZWWH8ysvMzAbMvbzMzKww7uVlZmYDFiFWO6GYmVkR/MrLzMwGbCi1ofRZz5I0UtKRkk6WtFOPc19vfmhmZsNDV6ju1g5qvbj7MfA+YAlwhqTvVJ37cFOjMjMbJirjUIZ6QtkxIj4eEd8F/hFYV9LlksbAEOk0bWbWArpQ3S0PSTMkLZY0v6psY0mzJD2Ufm7UrN+jVkJZq7ITEasj4gjgbuBXwLrNCsjMbDiJgNVdI+puOZ0LTO1RdhxwU0RMAW5Kx01RK8o5kroFFhEnAecAk5oVkJnZcFPUK6+IuA1Y2qN4P2Bm2p8J7F9c5N312csrIg7po/wnwE+aFZCZ2XAyCHN5bRYRT6T9J4HNmvUgdxs2MytZ5Eso4yXNqTqeHhHTG3tOhKRoKLgGOKGYmZUsZ6P70xHR0Y/b/03S5hHxhKTNgcX9uEcuQ2O8f6vq6io7AjNrcRFNH4dyFTAt7U8Drhxw0H2oW0ORdFNE7FavzLqbN+sPbL7Prhz+hs+wbN1xvH6HLZl+1pFlh2VmPfxt4VIu+eGvuG/uo2z+2k048LO78qYdXjuIEYjO/L24at9JugjYmez12ELgROBbwKWSDgceAw4s5GG96DOhSBoLjEuBbcTLY0/WB7ZoVkDt7MlFS5j2npNYvTqY+tKf+MqqF+hYexHXTnw78xc9w7t3PJ5fz/5PJA/jMWsFix55ii/u/z1WLF9J5+ou/vLQk9z1mwf5ync+zk57vXnQ4sjZhpLjPnFwH6cGpQJQKy0eCcwF3ph+VrYrgTObH1p7Oevbv+DQ7b9G56ou6Opi986HANjn0TkwQsS40XRO2pj37HlCyZGaWcW5376O5S+uoHN19no6AlYsX8VZ/345XYP0yroyl9eQHikfEd+LiMnAv0bEVhExOW1viYi2SSiSpkp6QNICSU0Z0LN8+Up+du6viVUr0KInWWfRQrZZ+hcAtl3yGONWvfRyPJ1utjJrFfNm/5noemWnpxeeW86zT78wOEFElsjqbe2gbhtKRHxf0rvIBjOOqio/r4lxFULSSOAHwB7AQuAPkq6KiPsKe8gzz/DZfb/O6xc8AitWAbADi1nFCNaii1UaxQf/PJs5m00BYOQLL3LrRT/nfVN3hY2aNgOCmeWwwcbrsmzpi68oj4Bx644ZtDhaYQng1MzxAeA9wGuA5cB84JqIuDfPPfI0yp8PvI5s2pXOVBxAyycUYEdgQUQ8DCDpYrJRo4UllPiv/2Lmb89iBSNYXVXhW4fV2c/OFRw+/0YOnz8LCEZ3rmbMx38Mxx4Lp55aVBhm1g8HHLEzPzjxClYsX7mmbPSYUbxn7+0YO25wEkoU2CjfX5K+AewL3AzMJutaPBZ4PfCtlGz+JSLuqXWfPONQOoCtI9ql0tXNFsDjVccLySa67EbSEcARABMnTmzoASv/42TOP+sWDnnxzjVJpKd1V69Ys//SqFGsOvFkRn/taw09x8yKt/tHOnjy8SVcNv0WRo0eyaqVnbz9fW/k6FMOGNQ4WuCv6x0RcWIf574j6VVA3T+OeRLKfODVwBP1Ptiu0mjT6QAdHR0N/atda+21uGj01tzNepzEb1mHVYzhlY15KzSSF0aO5Zh/Oojzv+7lZMxagSQ++eWpfPifdmbhw4vZdPMN2fhV6w96HEX18hqAcZLGRMSK3k5GxGJyDIjMU88aD9wn6QZJV1W2BoMtyyJgy6rjCamsMJLoUvDAiE04jKksZWyvn1s6YhwfPeiLnHvmj4t8vJkVYJ31xvKGt0wsKZlkCaXe1mQfBx6XdL6k96f254blqaH8R39u3CL+AEyRNJkskRxE9g+uUBf/8dt84rVHsXKttdh45Uu9fmajWM4mHVswcmS//j2Z2RBWdrfgiPiQpPWBDwFHA2dLuhK4KCJuzXufujWUdLNHgdFp/w/Anf2KepBFxGrgC8ANwP3ApXl7KzRisy03Zd+j9uRtq/7KarKEsXzkaFZqJMtHZDl7xJi1+NnrBnP0rZm1i1boNhwRz0XEzIjYG9gWuItstd7H61y6Rt2EIukzwGVkSwJD1tD9f/2ItxQRcW1EvD4iXhcRpzTrOV868zN884DXMI5VvKRRXDt+B/bb6atcvWUHnWPGstbyv8P55zfr8WbWpgLR1TWi7jZY0swoHwY+BmxM9vc/lzyvvD5P1v12NkBEPJRa/K3aypVwzTVo/fUZe+mlfGSvvfhI5dz118PHPgbXXAOrVsHo0WVGamYtpuxOXpLWJXvddTCwA9mEkicDtzTSwzdP2lsREWs6aUsaRfm/f+vp7IRp0+DBB2Gvvbqfmzo1Kz/0UFjde9diMxumWqNR/lFgL+AsYGJEHBkRNzc6XCRPDeVWSV8D1pa0B3AU8ItGox3y1l4bzjqr7/ObbVb7vJkNX+X/J/qWEbEcQNLakraKiAcavUmeGspxwFPAPLIJI68FPJDCzKwgZddQqpLJvmSzolyfjrdvZJhInrm8uoD/TZuZmRUogK6u0gc2VvwHWZv5LQARcXcadpFLnrm8dkoPeW36vLLnxFaNx2pmZt0EUP5I+YpVEbGsx5pNuV/I5WlDORv4MtlaKJ11PmtmZg1qgbm8Ku6V9HFgpKQpwBeB3+W9OE8byrKIuC4iFkfEksrW32jNzKyHyLENjqOBbYAVwIXAMuCYvBfnqaHcLOk04PL0EAAioi1Gy5uZtbZB6RacS0T8HTghbQ3Lk1Aq0713VD8X2LU/DzQzsx5KfuUl6X+BMyJiXi/n1iEbNb8iIi6odZ88vbx26XeUZmZWW0CU38vrB8C/SXoz2ZIlT5EtsDUFWB+YAdRMJpCvl9cGwInAe1PRrcBJEbGsf3GbmVl3xSQUSV8G/omszjMPOCwiep8CvUpE3A0cmKZg6QA2J1sC+P5GBjjmaZSfATwPHJi254Bz8j7AzMzqKKBRXtIWZL2yOiJiW2Ak2ZId+cOIeCEibomIiyLi/xodLZ+nDeV1EfGRquNvSLq7kYeYmVkNxbWhjCKbJmsVMA74a2F3ziFPDWW5pHdXDtJAx+XNC8nMbBipDGyst9W7TcQi4NvAX8iWbF8WETc2N/ju8tRQPgfMTG0pApYC05oalZnZMJJzYON4SXOqjqdHxPTKQVrHZD9gMvAs8DNJh0TETxuNJ63eGBHxfCPX5enldTfwlvQAIuK5RoMzM7Ma8vXyejoiOmqc3x14JCKeApB0OfAuIHdCkfR2snbz9bJDPQt8OiLm5rk+z4qNm0g6g2yysJslfU/SJnkDNDOz2hT1txz+ArxD0jhlk3HtRrb0eSPOBo6KiEkR8VqyBRZzd8LK04ZyMVmf5I8AB6T9SxoM0szMepOnh1eOhBIRs8mW672TrMvwCGB6zYteqTMifl11z98AuVcFzNOGsnlEnFx1/E1JH2sgQDMz61O+Rvc8IuJEsnGD/XWrpB8DF5GlsY8Bt0h6a7p/zSm38iSUGyUdBFyajg8Abuh/vGZm1k3rzDb8lvSzZ1LagRxTbuVJKJ8hm22y0rAzAnhR0pFkvQDWzx+rmZm9QlfZAWQGOtVWnl5e6w3kAWZmVkNrLbCFpH3IprAfWymLiJPyXJunhoKk7YBJ1Z+PiMsbitLMzHqVsxdX00n6EdkI+12An5A1cdyR9/o8k0POALYD7uXlilmQrY9iZmYD1SIJBXhXRGwn6Z6I+Iak/wGuy3txnhrKOyJi6/7HZ2ZmbaIyrdbfJb0GWEI283Auecah/F6SE4qZWZMUNLCxCFdL2hA4jWw8y6NkXYhzyVNDOY8sqTxJtgSwyHp3bdd4rGZm1k2Qd+qVpqsac/hzSVcDYxtZ+ypPQjkb+CTZyMsW6dxmZjaEtEgbiqQP91K2DJgXEYvrXZ8noTwVEVf1JzgzM6uvVXp5AYcD7wRuTsc7A3OByZJOiojza12cJ6HcJelC4Bdkr7wAdxs2MytM6ySUUcCbIuJvAJI2I2v2+EfgNmDACWVtskSyZ1WZuw2bmRWldRLKlpVkkixOZUvTKpA15Rkpf9hAojMzs74Nci+uem5JjfE/S8cfSWXrkC3aVVOe9VAmSLpC0uK0/VzShIHFbGZma3Sp/jY4KuufbJ+284DPR8SLeeb5yvPK6xzgQuCj6fiQVLZHv8I1M7NuWqWGEhEB/DxtDcszsHHTiDgnIlan7Vxg0/48zMzMelHAAlutIE9CWSLpEEkj03YI2XB8MzMbqByj5FulBlNPnoTyaeBA4EngCbLZJ91Qb2ZWlOFSQ4mIxyLigxGxaUS8KiL2j4i/DOShkj4q6V5JXZI6epw7XtICSQ9I2quqfGoqWyDpuKryyZJmp/JLJK2Vysek4wXp/KSBxGxm1izqqr819fnSPEn39LXlvU+fCUXSaWlVxp7lR0r6Vn8DT+YDHyYbKFN9762Bg8gWd5kKnFV51Qb8ANgb2Bo4uGrCylOB0yPiH4BnyEZ6kn4+k8pPT58zM7NX+gCwL3B92j6RtmvTlkutGsquwPReyv83PbzfIuL+iHigl1P7ARdHxIqIeARYAOyYtgUR8XBErAQuBvaTpBTnZen6mcD+VfeamfYvA3ZLnzczay0lv/JKb6IeA/aIiGMjYl7ajqP7oPaaaiWUMakLWc8Hd5HNONwMWwCPVx0vTGV9lW8CPBsRq3uUd7tXOr8sfd7MrHUU2CgvaUNJl0n6k6T7Jb2zwWgkaaeqg3eRr60dqD0OZbmkKRHxUI+nTeHlRVhqRfVL4NW9nDohIq7MG+BgkHQEcATAxIkTS47GzIad4mog3wOuj4gDUnvyuAavPxyYIWkDsorDM2Qds3KplVD+HbhO0jfJZpsE6ACOB46pd+OI2D1vEFUWAVtWHU9IZfRRvgTYUNKoVAup/nzlXgsljQI2oI/uzhExnfR6r6Ojo036U5jZkFHAX52UBN4LfAogNQ+sbCiMiLnAW9K9aGQtFKiRUCLiOkn7A18Bjk7F84GPRMS8Rh7SgKuACyV9B3gNMAW4gyxTTpE0mSxRHAR8PCJC0s1kXZkvBqYBV1bdaxrw+3T+V729wjMzK5MorBfXZOAp4BxJbyGrCHwpIl7MHYs0hmz+rknAqEqzc0SclOf6mlOvRMR8sj/KhZL0IeD7ZCPur5F0d0TsFRH3SroUuA9YTTaHTGe65gvADcBIYEZE3Jtu91Xg4lSTuotsQTDSz/MlLQCWkiUhM7PWkr+NZLykOVXH09PblYpRwFuBoyNitqTvAccB/9ZANFeStTfPpWq5krzyzOVVuIi4Ariij3OnAKf0Ut5r97WIeJisF1jP8pd4ef4xM7PWlS+hPB0RHTXOLwQWRsTsdHwZWUJpxISImNrgNWvkbr03M7MmKaDbcEQ8CTwu6Q2paDeytz2N+J2kNzd4zRql1FDMzOxlBc7VdTRwQerh9TCNT5P1buBTkh4he+UlskmIt8tzcZ8JRdKlEXFg2j81Ir5ade7GiMg92MXMzGooKKFExN1kvXH7a++BPL/WK68pVfs91z7x9PVmZkWI8ufyWhPKyyPml9OPcfq1Ekqtm7j7rZlZUVpktmFJH5T0EPAIcCvwKHBd3utrtaGMk7QDWdJZO+0rbWv3O2IzM+umhdY7ORl4B/DLiNhB0i5kq/TmUiuhPAl8p5f9yrGZmRWhdRLKqohYImmEpBERcbOk7+a9uNZI+Z0LCc/MzPrWWgtoPStpXbKlRS6QtBjIPdK+Vi+v99a6MCJuq3XezMzqEy31yms/sgb5L5Oth7IBkGvaFaj9yusrvZQFsB3ZpIsj88doAJ2dXaxcsYqxa6+Fl2Yxs4pWSShV8351SboGWNLIHIi1XnntW32c5sj/Oln7ydG9XmS96urq4qc/voXLL/w9K1esZsON1+HIf96L9+3Z7wGpZjaUlJxQJL0D+BbZvIcnA+cD44ERkg6NiOvz3KfuSHlJu5FNLhbAf0bErH5HPUyde9ZN/N9Fs1nx0ioAljz1PP/zjSsZt+5Y3v6uKXWuNrMhr/waypnA18hecf0K2Dsibpf0RuAismWB66q1pvw+kn4H/Cvw9YjYxcmkcStXrubKi19OJhUrXlrF+T++uaSozKxlFLhi4wCMiogbI+JnwJMRcTtARPypoZvUOPcLstkrlwDHSjq2+mREfLDBgIel55f9na6u3r8NTyx8ZpCjMbOWVH4NpXosfs8VeQfehgLs0lA41qsNN1qH0aNHsXLF6lec22rKZiVEZGatZrCmVqnhLZKeIw1cT/uk47F5b1KrUf7W6mNJo4FtgUURsbjxeIenkaNG8snP7sw5Z97U7bXXmLGj+dTndysxMjNrFWX38oqIQnrt1hqH8iPg+2kVxQ3IltLtBDaW9K8RcVERAQwHHzr4nay3/tpcMP1Wljz9PFu9/tV85kt78qY3b1l2aGZWttYa2DggtV55vSciPpv2DwMejIj9Jb2abLIwJ5QG7L7P9uy+z/Zlh2FmrWgYJJSVVft7AD+DbFUwD8ozMytGi42UH5BaCeVZSR8AFgE7AYcDSBqFZxs2MyuM+ugJ2m5qJZQjgTOAVwPHpPWKIVun+JpmB2ZmNiwMhzaUiHgQmNpL+Q3ADc0MysxsOBkqr7xqrdj4CpLubFYgZmbDVous2DhQdefy6sGt8WZmBRuWNRTcdmJmVrwCayiSRkq6S9LVxQdaW92EIunUyn5EfL1nmZmZDUBkU6/U2xrwJeD+5gRbW54ayh69lO1ddCBmZsNRZRxKEbMNS5oA7AP8pIkh96nW1CufA44CtpJ0T9Wp9YDfNjswM7NhI/+iiPV8FziW7O/0oKvVKH8h2RQr/wUcV1X+fEQsbWpUZmbDSM4ayHhJc6qOp0fE9DX3yAaiL46IuZJ2LjbCfGqNQ1kGLAMOHrxwzMyGmfyN7k9HREeN8zsBH5T0frIp59eX9NOIOGTgQebTaC8vMzMrWBGN8hFxfERMiIhJwEHArwYzmUDj41DMzKxgLbDAViGcUMzMyhQU2Sif3TLiFuCWQm+agxOKmVnJhspIeScUM7OyOaGYmdlADZcFtszMrNkihsUCW2ZmNhiGRj4pZxyKpNMk/UnSPZKukLRh1bnjJS2Q9ICkvarKp6ayBZKOqyqfLGl2Kr9E0lqpfEw6XpDOTxrM39HMLK+i5vIqW1kDG2cB20bEdsCDwPEAkrYmG5CzDdlqkWelqZhHAj8gm5Rya+Dg9FmAU4HTI+IfgGeAw1P54cAzqfz09Dkzs9YSQFfU39pAKQklIm6MiNXp8HZgQtrfD7g4IlZExCPAAmDHtC2IiIcjYiVwMbCfJAG7Apel62cC+1fda2bavwzYLX3ezKy1DJEVG1th6pVPk01CCbAF8HjVuYWprK/yTYBnq5JTpbzbvdL5ZenzZmYtZai88mpao7ykXwKv7uXUCRFxZfrMCcBq4IJmxZGHpCOAIwAmTpxYZihmNgy5l1cdEbF7rfOSPgV8ANgtYs28A4uALas+NiGV0Uf5EmBDSaNSLaT685V7LZQ0Ctggfb63WKcD0wE6OjqGxr9ZM2sPbfRKq56yenlNJVsE5oMR8feqU1cBB6UeWpOBKcAdwB+AKalH11pkDfdXpUR0M3BAun4acGXVvaal/QPIZt4cIv/azGyoyAY2Rt2tHZQ1DuVMYAwwK7WT3x4Rn42IeyVdCtxH9irs8xHRCSDpC8ANwEhgRkTcm+71VeBiSd8E7gLOTuVnA+dLWgAsJUtCZmatx7MN91/qytvXuVOAU3opvxa4tpfyh8l6gfUsfwn46MAiNTNrvnapgdTjkfJmZmUaQm0oTihmZqXyXF5mZlYUv/IyM7MBCy8BbGZmRXENxczMCjE08okTiplZ2dQ1NN55tcLkkGZmw1eQDWyst9UhaUtJN0u6T9K9kr7UtJj74BqKmVmJRGFTq6wG/iUi7pS0HjBX0qyIuK+Im+fhGoqZWdki6m91bxFPRMSdaf954H5eXs5jULiGYmZWtoJ7eaUlz3cAZhd64zqcUMzMylRpQ6lvvKQ5VcfT09Ib3UhaF/g5cExEPFdIjDk5oZiZlSxnL6+nI6Kj5n2k0WTJ5IKIuLyI2BrhhGJmVqp8bST1KFsL5Gzg/oj4zoBv2A9ulDczK1NQSKM8sBPwSWBXSXen7f1Njb0H11DMzMpWwLjGiPgN2QKQpXFCMTMrmRfYMjOzYjihmJnZgEVA59CYy8sJxcysbK6hmJlZIZxQzMxswALwmvJmZjZwAeE2FDMzG6jAjfJmZlYQt6GYmVkhnFDMzGzgipkcshU4oZiZlSmAfNPXtzwnFDOzsrmGYmZmA+epV8zMrAgB4XEoZmZWCI+UNzOzQrgNxczMBizCvbzMzKwgrqGYmdnABdHZWXYQhXBCMTMrk6evNzOzwrjbsJmZDVQA4RqKmZkNWHiBLTMzK8hQaZRXDJHuakWR9BTwWIG3HA88XeD9BpNjL4djL0+j8b82IjYdyAMlXZ+eW8/TETF1IM9qNieUJpM0JyI6yo6jPxx7ORx7edo9/rKNKDsAMzMbGpxQzMysEE4ozTe97AAGwLGXw7GXp93jL5XbUMzMrBCuoZiZWSGcUJpE0lRJD0haIOm4EuOYIWmxpPlVZRtLmiXpofRzo1QuSWekmO+R9Naqa6alzz8kaVpV+dskzUvXnCFJBca+paSbJd0n6V5JX2qX+CWNlXSHpD+m2L+RyidLmp2ed4mktVL5mHS8IJ2fVHWv41P5A5L2qipv6ndM0khJd0m6ug1jfzT9e71b0pxU1vLfm7YXEd4K3oCRwJ+BrYC1gD8CW5cUy3uBtwLzq8r+Gzgu7R8HnJr23w9cBwh4BzA7lW8MPJx+bpT2N0rn7kifVbp27wJj3xx4a9pfD3gQ2Lod4k/3WzftjwZmp+dcChyUyn8EfC7tHwX8KO0fBFyS9rdO358xwOT0vRo5GN8x4J+BC4Gr03E7xf4oML5HWct/b9p9cw2lOXYEFkTEwxGxErgY2K+MQCLiNmBpj+L9gJlpfyawf1VQQJFFAAAGY0lEQVT5eZG5HdhQ0ubAXsCsiFgaEc8As4Cp6dz6EXF7ZP8vO6/qXkXE/kRE3Jn2nwfuB7Zoh/hTDC+kw9FpC2BX4LI+Yq/8TpcBu6X/6t0PuDgiVkTEI8ACsu9XU79jkiYA+wA/Scdql9hraPnvTbtzQmmOLYDHq44XprJWsVlEPJH2nwQ2S/t9xV2rfGEv5YVLr1F2IPsv/baIP70yuhtYTPbH6M/AsxGxupfnrYkxnV8GbNKP36ko3wWOBSqTTG3SRrFDlrxvlDRX0hGprC2+N+3Mc3kNcxERklq6q5+kdYGfA8dExHPVr6tbOf6I6AS2l7QhcAXwxpJDykXSB4DFETFX0s5lx9NP746IRZJeBcyS9Kfqk638vWlnrqE0xyJgy6rjCamsVfwtVdtJPxen8r7irlU+oZfywkgaTZZMLoiIy9stfoCIeBa4GXgn2euUyn/IVT9vTYzp/AbAkjqxN+s7thPwQUmPkr2O2hX4XpvEDkBELEo/F5Ml8x1ps+9NWyq7EWcobmQ1v4fJGiIrjY7blBjPJLo3yp9G98bJ/077+9C9cfKOVL4x8AhZw+RGaX/jdK5n4+T7C4xbZO+nv9ujvOXjBzYFNkz7awO/Bj4A/IzuDdtHpf3P071h+9K0vw3dG7YfJmvUHpTvGLAzLzfKt0XswDrAelX7vwOmtsP3pt230gMYqhtZz5EHyd6bn1BiHBcBTwCryN71Hk72fvsm4CHgl1X/JxHwgxTzPKCj6j6fJmtUXQAcVlXeAcxP15xJGixbUOzvJnsXfg9wd9re3w7xA9sBd6XY5wP/nsq3Sn+MFqQ/0GNS+dh0vCCd36rqXiek+B6gqjfRYHzH6J5Q2iL2FOcf03Zv5f7t8L1p980j5c3MrBBuQzEzs0I4oZiZWSGcUMzMrBBOKGZmVggnFDMzK4QTijWdpA0lHVXj/Bsk3ZJmhr1f0vRUvrOkkLRv1WevrozeTtc8kK67W9Jlfdx/b0lzlM1afJek/yn4Vxx0ko6RNK6Pc19Is+CGpPGDHZsNX04oNhg2JJuRti9nAKdHxPYR8Sbg+1XnFpKNZejLJ9J120fEAT1PStqWbJzAIRGxNdn4gQUN/wat5xig14QC/BbYHXhs8MIxc0KxwfEt4HWpFnFaL+c3p2qyvYiYV3Xuj8AySXv089nHAqdExJ/SvTsj4oeQTTgp6VdpDYybJE1M5edK+qGk2yU9nGpKM1Lt6dzKjSW9IOl0Zeud3CRp01S+fbr2HklXVK27cYukU5Wtk/KgpPek8pGSTpP0h3TNkal853TNZZL+JOmCtHbHF4HXADdLurnnLxwRd0XEo/3852XWb04oNhiOA/6cahFf6eX86cCvJF0n6ctpMsVqpwBf7+PeF1S98uotWW0LzO3j2u8DMyNiO+ACsppSxUZkc299GbgqxbgN8GZJ26fPrAPMiYhtgFuBE1P5ecBX033nVZUDjIqIHclqGJXyw4FlEfF24O3AZyRNTud2SJ/dmmwE+E4RcQbwV2CXiNilj9/NbNA5oVjpIuIc4E1k03fsDNwuaUzV+dsAJL27l8urX3n1lqxqeSfZAlIA55NN9VLxi8imkZgH/C0i5kVEF9lUHpPSZ7qAS9L+T4F3S9qAbA6vW1P5TLJFzioqE1zOrbrPnsChaar72WRThExJ5+6IiIXp2XdXXWPWcpxQbNBJOqVSq6iURcRfI2JGROwHrCarWVSrVUup5V7gbf24bkX62VW1Xznua9mHPPMYVe7VWXUfAUdXJcbJEXFjj8/3vMas5Tih2GB4nmwJXwAi4oTKH09Ys7746LT/arL/Qu82HXj6A7sR2aSLjTgN+Jqk16f7j5D02XTud2Sz4wJ8gmxG4EaMACodAT4O/CYilgHPVNpHgE+SvQ6r5Qbgc1X/DF4vaZ0613T7Z2rWCpxQrOkiYgnwW0nz+2jn2BOYL+mPZH9cvxIRT/byuVPovj4FdG9D+WUvz76HrA3iIkn3k80Qu1U6fTRwmKR7yP7wf6nBX+1FYEdJ88nWDDkplU8DTkv33b6qvC8/Ae4D7kz3+jH1ayLTget7a5SX9EVJC8nW6bhH0k/y/kJmA+HZhs36SdILEbFu2XGYtQrXUMzMrBCuoZiZWSFcQzEzs0I4oZiZWSGcUMzMrBBOKGZmVggnFDMzK4QTipmZFeL/ARjbdpGz6VvkAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x10f104978>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "uid = \"1160/3/0478C7E0B7C4F75C6081EC5184522704\"\n",
+    "cr3se4_index = gap_projection.uids.index(uid)\n",
+    "print(\"{}, Band gap: {}, URL: https://citrination.com/pif/{}\"\n",
+    "      .format(gap_projection.tags[cr3se4_index],\n",
+    "              gap_projection.responses[cr3se4_index],\n",
+    "              gap_projection.uids[cr3se4_index])\n",
+    "     )\n",
+    "print(\"Similar materials:\")\n",
+    "for idx in find_most_similar_materials(cr3se4_index, coordinates_and_bg[:,0:2]):\n",
+    "    print(\"{}, Band gap: {}, URL: https://citrination.com/pif/{}\"\n",
+    "          .format(gap_projection.tags[idx],\n",
+    "                  gap_projection.responses[idx],\n",
+    "                  gap_projection.uids[idx])\n",
+    "         )\n",
+    "plt.figure()\n",
+    "plt.scatter(gap_projection.xs, gap_projection.ys, c=gap_projection.responses)\n",
+    "plt.colorbar(label=\"Band gap (eV)\")\n",
+    "plt.scatter(coordinates_and_bg[cr3se4_index, 0], coordinates_and_bg[cr3se4_index, 1],\n",
+    "            marker=\"*\", c=\"r\", s=200)\n",
+    "plt.xlabel(\"t-SNE Component 1\")\n",
+    "plt.ylabel(\"t-SNE Component 2\")\n",
+    "plt.axes().set_aspect('equal', 'datalim')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we've seen here, t-SNE is a useful tool for understanding materials datasets and gaining new insights by visualizing and exploring a large, high-dimensional dataset in two dimensions. In this tutorial, we've seen how to examine outliers, find interesting clusters of similar materials, and find materials that are similar to a given material, which are only some of the cool things that you can do with t-SNE plots. The t-SNE analysis is available for all real-valued outputs specified in the Data Views creation process."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Copied the eight broken notebooks as *-4.ipynb then, made them work with pyCC 4.0.0 API.  Tested on Python 2.7.12 and 3.6.4.  It should mitigate the issue #23.

Notes:
    No edits were made to the text (not sure still correct with pyCC 4.)
    Apparently, the results/figures are not exactly the same as the original.