### PR TITLE
Removed links to citrination.org; links in README already

### DIFF
--- a/AdvancedPif.ipynb
+++ b/AdvancedPif.ipynb
@@ -587,7 +587,7 @@
    "source": [
     "### creating a dataset\n",
     "\n",
-    "If you have been completing the API Example tutorials in the order in which they're presented on [Citrination.org/learn](https://citrination.org/learn/api-examples/), feel free to use the dataset id you created previously. Otherwise, the cell below will use the `citrination_client` to create a new dataset and corresponding `dataset_id`."
+    "If you have been completing the API Example tutorials in the order in which they're presented in the [README](README.md), feel free to use the dataset id you created previously. Otherwise, the cell below will use the `citrination_client` to create a new dataset and corresponding `dataset_id`."
    ]
   },
   {
@@ -692,7 +692,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/IntroQueries.html
+++ b/IntroQueries.html
@@ -1,8 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head><meta charset="utf-8" />
-<title>IntroQueries</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+
+<title>IntroQueries</title>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
+
+
 
 <style type="text/css">
     /*!
@@ -199,7 +204,6 @@ th {
   *:before,
   *:after {
     background: transparent !important;
-    color: #000 !important;
     box-shadow: none !important;
     text-shadow: none !important;
   }
@@ -6744,15 +6748,15 @@ button.close {
 *
 */
 /*!
- *  Font Awesome 4.2.0 by @davegandy - http://fontawesome.io - @fontawesome
+ *  Font Awesome 4.7.0 by @davegandy - http://fontawesome.io - @fontawesome
  *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
  */
 /* FONT PATH
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.2.0');
-  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.2.0') format('embedded-opentype'), url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.2.0') format('woff'), url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.2.0') format('truetype'), url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular') format('svg');
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?v=4.7.0');
+  src: url('../components/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.7.0') format('embedded-opentype'), url('../components/font-awesome/fonts/fontawesome-webfont.woff2?v=4.7.0') format('woff2'), url('../components/font-awesome/fonts/fontawesome-webfont.woff?v=4.7.0') format('woff'), url('../components/font-awesome/fonts/fontawesome-webfont.ttf?v=4.7.0') format('truetype'), url('../components/font-awesome/fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -6809,6 +6813,19 @@ button.close {
   border: solid 0.08em #eee;
   border-radius: .1em;
 }
+.fa-pull-left {
+  float: left;
+}
+.fa-pull-right {
+  float: right;
+}
+.fa.fa-pull-left {
+  margin-right: .3em;
+}
+.fa.fa-pull-right {
+  margin-left: .3em;
+}
+/* Deprecated as of 4.4.0 */
 .pull-right {
   float: right;
 }
@@ -6824,6 +6841,10 @@ button.close {
 .fa-spin {
   -webkit-animation: fa-spin 2s infinite linear;
   animation: fa-spin 2s infinite linear;
+}
+.fa-pulse {
+  -webkit-animation: fa-spin 1s infinite steps(8);
+  animation: fa-spin 1s infinite steps(8);
 }
 @-webkit-keyframes fa-spin {
   0% {
@@ -6846,31 +6867,31 @@ button.close {
   }
 }
 .fa-rotate-90 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
   -webkit-transform: rotate(90deg);
   -ms-transform: rotate(90deg);
   transform: rotate(90deg);
 }
 .fa-rotate-180 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
   -webkit-transform: rotate(180deg);
   -ms-transform: rotate(180deg);
   transform: rotate(180deg);
 }
 .fa-rotate-270 {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
   -webkit-transform: rotate(270deg);
   -ms-transform: rotate(270deg);
   transform: rotate(270deg);
 }
 .fa-flip-horizontal {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
   -webkit-transform: scale(-1, 1);
   -ms-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
 .fa-flip-vertical {
-  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1);
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
   -webkit-transform: scale(1, -1);
   -ms-transform: scale(1, -1);
   transform: scale(1, -1);
@@ -7355,6 +7376,7 @@ button.close {
 .fa-twitter:before {
   content: "\f099";
 }
+.fa-facebook-f:before,
 .fa-facebook:before {
   content: "\f09a";
 }
@@ -7367,6 +7389,7 @@ button.close {
 .fa-credit-card:before {
   content: "\f09d";
 }
+.fa-feed:before,
 .fa-rss:before {
   content: "\f09e";
 }
@@ -8004,7 +8027,8 @@ button.close {
 .fa-male:before {
   content: "\f183";
 }
-.fa-gittip:before {
+.fa-gittip:before,
+.fa-gratipay:before {
   content: "\f184";
 }
 .fa-sun-o:before {
@@ -8108,7 +8132,7 @@ button.close {
 .fa-digg:before {
   content: "\f1a6";
 }
-.fa-pied-piper:before {
+.fa-pied-piper-pp:before {
   content: "\f1a7";
 }
 .fa-pied-piper-alt:before {
@@ -8234,6 +8258,7 @@ button.close {
   content: "\f1ce";
 }
 .fa-ra:before,
+.fa-resistance:before,
 .fa-rebel:before {
   content: "\f1d0";
 }
@@ -8247,6 +8272,8 @@ button.close {
 .fa-git:before {
   content: "\f1d3";
 }
+.fa-y-combinator-square:before,
+.fa-yc-square:before,
 .fa-hacker-news:before {
   content: "\f1d4";
 }
@@ -8414,6 +8441,657 @@ button.close {
 }
 .fa-meanpath:before {
   content: "\f20c";
+}
+.fa-buysellads:before {
+  content: "\f20d";
+}
+.fa-connectdevelop:before {
+  content: "\f20e";
+}
+.fa-dashcube:before {
+  content: "\f210";
+}
+.fa-forumbee:before {
+  content: "\f211";
+}
+.fa-leanpub:before {
+  content: "\f212";
+}
+.fa-sellsy:before {
+  content: "\f213";
+}
+.fa-shirtsinbulk:before {
+  content: "\f214";
+}
+.fa-simplybuilt:before {
+  content: "\f215";
+}
+.fa-skyatlas:before {
+  content: "\f216";
+}
+.fa-cart-plus:before {
+  content: "\f217";
+}
+.fa-cart-arrow-down:before {
+  content: "\f218";
+}
+.fa-diamond:before {
+  content: "\f219";
+}
+.fa-ship:before {
+  content: "\f21a";
+}
+.fa-user-secret:before {
+  content: "\f21b";
+}
+.fa-motorcycle:before {
+  content: "\f21c";
+}
+.fa-street-view:before {
+  content: "\f21d";
+}
+.fa-heartbeat:before {
+  content: "\f21e";
+}
+.fa-venus:before {
+  content: "\f221";
+}
+.fa-mars:before {
+  content: "\f222";
+}
+.fa-mercury:before {
+  content: "\f223";
+}
+.fa-intersex:before,
+.fa-transgender:before {
+  content: "\f224";
+}
+.fa-transgender-alt:before {
+  content: "\f225";
+}
+.fa-venus-double:before {
+  content: "\f226";
+}
+.fa-mars-double:before {
+  content: "\f227";
+}
+.fa-venus-mars:before {
+  content: "\f228";
+}
+.fa-mars-stroke:before {
+  content: "\f229";
+}
+.fa-mars-stroke-v:before {
+  content: "\f22a";
+}
+.fa-mars-stroke-h:before {
+  content: "\f22b";
+}
+.fa-neuter:before {
+  content: "\f22c";
+}
+.fa-genderless:before {
+  content: "\f22d";
+}
+.fa-facebook-official:before {
+  content: "\f230";
+}
+.fa-pinterest-p:before {
+  content: "\f231";
+}
+.fa-whatsapp:before {
+  content: "\f232";
+}
+.fa-server:before {
+  content: "\f233";
+}
+.fa-user-plus:before {
+  content: "\f234";
+}
+.fa-user-times:before {
+  content: "\f235";
+}
+.fa-hotel:before,
+.fa-bed:before {
+  content: "\f236";
+}
+.fa-viacoin:before {
+  content: "\f237";
+}
+.fa-train:before {
+  content: "\f238";
+}
+.fa-subway:before {
+  content: "\f239";
+}
+.fa-medium:before {
+  content: "\f23a";
+}
+.fa-yc:before,
+.fa-y-combinator:before {
+  content: "\f23b";
+}
+.fa-optin-monster:before {
+  content: "\f23c";
+}
+.fa-opencart:before {
+  content: "\f23d";
+}
+.fa-expeditedssl:before {
+  content: "\f23e";
+}
+.fa-battery-4:before,
+.fa-battery:before,
+.fa-battery-full:before {
+  content: "\f240";
+}
+.fa-battery-3:before,
+.fa-battery-three-quarters:before {
+  content: "\f241";
+}
+.fa-battery-2:before,
+.fa-battery-half:before {
+  content: "\f242";
+}
+.fa-battery-1:before,
+.fa-battery-quarter:before {
+  content: "\f243";
+}
+.fa-battery-0:before,
+.fa-battery-empty:before {
+  content: "\f244";
+}
+.fa-mouse-pointer:before {
+  content: "\f245";
+}
+.fa-i-cursor:before {
+  content: "\f246";
+}
+.fa-object-group:before {
+  content: "\f247";
+}
+.fa-object-ungroup:before {
+  content: "\f248";
+}
+.fa-sticky-note:before {
+  content: "\f249";
+}
+.fa-sticky-note-o:before {
+  content: "\f24a";
+}
+.fa-cc-jcb:before {
+  content: "\f24b";
+}
+.fa-cc-diners-club:before {
+  content: "\f24c";
+}
+.fa-clone:before {
+  content: "\f24d";
+}
+.fa-balance-scale:before {
+  content: "\f24e";
+}
+.fa-hourglass-o:before {
+  content: "\f250";
+}
+.fa-hourglass-1:before,
+.fa-hourglass-start:before {
+  content: "\f251";
+}
+.fa-hourglass-2:before,
+.fa-hourglass-half:before {
+  content: "\f252";
+}
+.fa-hourglass-3:before,
+.fa-hourglass-end:before {
+  content: "\f253";
+}
+.fa-hourglass:before {
+  content: "\f254";
+}
+.fa-hand-grab-o:before,
+.fa-hand-rock-o:before {
+  content: "\f255";
+}
+.fa-hand-stop-o:before,
+.fa-hand-paper-o:before {
+  content: "\f256";
+}
+.fa-hand-scissors-o:before {
+  content: "\f257";
+}
+.fa-hand-lizard-o:before {
+  content: "\f258";
+}
+.fa-hand-spock-o:before {
+  content: "\f259";
+}
+.fa-hand-pointer-o:before {
+  content: "\f25a";
+}
+.fa-hand-peace-o:before {
+  content: "\f25b";
+}
+.fa-trademark:before {
+  content: "\f25c";
+}
+.fa-registered:before {
+  content: "\f25d";
+}
+.fa-creative-commons:before {
+  content: "\f25e";
+}
+.fa-gg:before {
+  content: "\f260";
+}
+.fa-gg-circle:before {
+  content: "\f261";
+}
+.fa-tripadvisor:before {
+  content: "\f262";
+}
+.fa-odnoklassniki:before {
+  content: "\f263";
+}
+.fa-odnoklassniki-square:before {
+  content: "\f264";
+}
+.fa-get-pocket:before {
+  content: "\f265";
+}
+.fa-wikipedia-w:before {
+  content: "\f266";
+}
+.fa-safari:before {
+  content: "\f267";
+}
+.fa-chrome:before {
+  content: "\f268";
+}
+.fa-firefox:before {
+  content: "\f269";
+}
+.fa-opera:before {
+  content: "\f26a";
+}
+.fa-internet-explorer:before {
+  content: "\f26b";
+}
+.fa-tv:before,
+.fa-television:before {
+  content: "\f26c";
+}
+.fa-contao:before {
+  content: "\f26d";
+}
+.fa-500px:before {
+  content: "\f26e";
+}
+.fa-amazon:before {
+  content: "\f270";
+}
+.fa-calendar-plus-o:before {
+  content: "\f271";
+}
+.fa-calendar-minus-o:before {
+  content: "\f272";
+}
+.fa-calendar-times-o:before {
+  content: "\f273";
+}
+.fa-calendar-check-o:before {
+  content: "\f274";
+}
+.fa-industry:before {
+  content: "\f275";
+}
+.fa-map-pin:before {
+  content: "\f276";
+}
+.fa-map-signs:before {
+  content: "\f277";
+}
+.fa-map-o:before {
+  content: "\f278";
+}
+.fa-map:before {
+  content: "\f279";
+}
+.fa-commenting:before {
+  content: "\f27a";
+}
+.fa-commenting-o:before {
+  content: "\f27b";
+}
+.fa-houzz:before {
+  content: "\f27c";
+}
+.fa-vimeo:before {
+  content: "\f27d";
+}
+.fa-black-tie:before {
+  content: "\f27e";
+}
+.fa-fonticons:before {
+  content: "\f280";
+}
+.fa-reddit-alien:before {
+  content: "\f281";
+}
+.fa-edge:before {
+  content: "\f282";
+}
+.fa-credit-card-alt:before {
+  content: "\f283";
+}
+.fa-codiepie:before {
+  content: "\f284";
+}
+.fa-modx:before {
+  content: "\f285";
+}
+.fa-fort-awesome:before {
+  content: "\f286";
+}
+.fa-usb:before {
+  content: "\f287";
+}
+.fa-product-hunt:before {
+  content: "\f288";
+}
+.fa-mixcloud:before {
+  content: "\f289";
+}
+.fa-scribd:before {
+  content: "\f28a";
+}
+.fa-pause-circle:before {
+  content: "\f28b";
+}
+.fa-pause-circle-o:before {
+  content: "\f28c";
+}
+.fa-stop-circle:before {
+  content: "\f28d";
+}
+.fa-stop-circle-o:before {
+  content: "\f28e";
+}
+.fa-shopping-bag:before {
+  content: "\f290";
+}
+.fa-shopping-basket:before {
+  content: "\f291";
+}
+.fa-hashtag:before {
+  content: "\f292";
+}
+.fa-bluetooth:before {
+  content: "\f293";
+}
+.fa-bluetooth-b:before {
+  content: "\f294";
+}
+.fa-percent:before {
+  content: "\f295";
+}
+.fa-gitlab:before {
+  content: "\f296";
+}
+.fa-wpbeginner:before {
+  content: "\f297";
+}
+.fa-wpforms:before {
+  content: "\f298";
+}
+.fa-envira:before {
+  content: "\f299";
+}
+.fa-universal-access:before {
+  content: "\f29a";
+}
+.fa-wheelchair-alt:before {
+  content: "\f29b";
+}
+.fa-question-circle-o:before {
+  content: "\f29c";
+}
+.fa-blind:before {
+  content: "\f29d";
+}
+.fa-audio-description:before {
+  content: "\f29e";
+}
+.fa-volume-control-phone:before {
+  content: "\f2a0";
+}
+.fa-braille:before {
+  content: "\f2a1";
+}
+.fa-assistive-listening-systems:before {
+  content: "\f2a2";
+}
+.fa-asl-interpreting:before,
+.fa-american-sign-language-interpreting:before {
+  content: "\f2a3";
+}
+.fa-deafness:before,
+.fa-hard-of-hearing:before,
+.fa-deaf:before {
+  content: "\f2a4";
+}
+.fa-glide:before {
+  content: "\f2a5";
+}
+.fa-glide-g:before {
+  content: "\f2a6";
+}
+.fa-signing:before,
+.fa-sign-language:before {
+  content: "\f2a7";
+}
+.fa-low-vision:before {
+  content: "\f2a8";
+}
+.fa-viadeo:before {
+  content: "\f2a9";
+}
+.fa-viadeo-square:before {
+  content: "\f2aa";
+}
+.fa-snapchat:before {
+  content: "\f2ab";
+}
+.fa-snapchat-ghost:before {
+  content: "\f2ac";
+}
+.fa-snapchat-square:before {
+  content: "\f2ad";
+}
+.fa-pied-piper:before {
+  content: "\f2ae";
+}
+.fa-first-order:before {
+  content: "\f2b0";
+}
+.fa-yoast:before {
+  content: "\f2b1";
+}
+.fa-themeisle:before {
+  content: "\f2b2";
+}
+.fa-google-plus-circle:before,
+.fa-google-plus-official:before {
+  content: "\f2b3";
+}
+.fa-fa:before,
+.fa-font-awesome:before {
+  content: "\f2b4";
+}
+.fa-handshake-o:before {
+  content: "\f2b5";
+}
+.fa-envelope-open:before {
+  content: "\f2b6";
+}
+.fa-envelope-open-o:before {
+  content: "\f2b7";
+}
+.fa-linode:before {
+  content: "\f2b8";
+}
+.fa-address-book:before {
+  content: "\f2b9";
+}
+.fa-address-book-o:before {
+  content: "\f2ba";
+}
+.fa-vcard:before,
+.fa-address-card:before {
+  content: "\f2bb";
+}
+.fa-vcard-o:before,
+.fa-address-card-o:before {
+  content: "\f2bc";
+}
+.fa-user-circle:before {
+  content: "\f2bd";
+}
+.fa-user-circle-o:before {
+  content: "\f2be";
+}
+.fa-user-o:before {
+  content: "\f2c0";
+}
+.fa-id-badge:before {
+  content: "\f2c1";
+}
+.fa-drivers-license:before,
+.fa-id-card:before {
+  content: "\f2c2";
+}
+.fa-drivers-license-o:before,
+.fa-id-card-o:before {
+  content: "\f2c3";
+}
+.fa-quora:before {
+  content: "\f2c4";
+}
+.fa-free-code-camp:before {
+  content: "\f2c5";
+}
+.fa-telegram:before {
+  content: "\f2c6";
+}
+.fa-thermometer-4:before,
+.fa-thermometer:before,
+.fa-thermometer-full:before {
+  content: "\f2c7";
+}
+.fa-thermometer-3:before,
+.fa-thermometer-three-quarters:before {
+  content: "\f2c8";
+}
+.fa-thermometer-2:before,
+.fa-thermometer-half:before {
+  content: "\f2c9";
+}
+.fa-thermometer-1:before,
+.fa-thermometer-quarter:before {
+  content: "\f2ca";
+}
+.fa-thermometer-0:before,
+.fa-thermometer-empty:before {
+  content: "\f2cb";
+}
+.fa-shower:before {
+  content: "\f2cc";
+}
+.fa-bathtub:before,
+.fa-s15:before,
+.fa-bath:before {
+  content: "\f2cd";
+}
+.fa-podcast:before {
+  content: "\f2ce";
+}
+.fa-window-maximize:before {
+  content: "\f2d0";
+}
+.fa-window-minimize:before {
+  content: "\f2d1";
+}
+.fa-window-restore:before {
+  content: "\f2d2";
+}
+.fa-times-rectangle:before,
+.fa-window-close:before {
+  content: "\f2d3";
+}
+.fa-times-rectangle-o:before,
+.fa-window-close-o:before {
+  content: "\f2d4";
+}
+.fa-bandcamp:before {
+  content: "\f2d5";
+}
+.fa-grav:before {
+  content: "\f2d6";
+}
+.fa-etsy:before {
+  content: "\f2d7";
+}
+.fa-imdb:before {
+  content: "\f2d8";
+}
+.fa-ravelry:before {
+  content: "\f2d9";
+}
+.fa-eercast:before {
+  content: "\f2da";
+}
+.fa-microchip:before {
+  content: "\f2db";
+}
+.fa-snowflake-o:before {
+  content: "\f2dc";
+}
+.fa-superpowers:before {
+  content: "\f2dd";
+}
+.fa-wpexplorer:before {
+  content: "\f2de";
+}
+.fa-meetup:before {
+  content: "\f2e0";
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
 }
 /*!
 *
@@ -8694,6 +9372,10 @@ div.traceback-wrapper {
   max-width: 800px;
   margin: auto;
 }
+div.traceback-wrapper pre.traceback {
+  max-height: 600px;
+  overflow: auto;
+}
 /**
  * Primary styles
  *
@@ -8719,6 +9401,10 @@ body > #header {
   z-index: 100;
 }
 body > #header #header-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 5px;
   padding-bottom: 5px;
   padding-top: 5px;
   box-sizing: border-box;
@@ -8750,13 +9436,16 @@ body > #header .header-bar {
   padding-top: 1px;
   padding-bottom: 1px;
 }
-@media (max-width: 991px) {
-  #ipython_notebook {
-    margin-left: 10px;
-  }
-}
 [dir="rtl"] #ipython_notebook {
+  margin-right: 10px;
+  margin-left: 0;
+}
+[dir="rtl"] #ipython_notebook.pull-left {
   float: right !important;
+  float: right;
+}
+.flex-spacer {
+  flex: 1;
 }
 #noscript {
   width: auto;
@@ -8791,8 +9480,14 @@ body > #header .header-bar {
 input.ui-button {
   padding: 0.3em 0.9em;
 }
+span#kernel_logo_widget {
+  margin: 0 10px;
+}
 span#login_widget {
   float: right;
+}
+[dir="rtl"] span#login_widget {
+  float: left;
 }
 span#login_widget > .button,
 #logout {
@@ -8908,6 +9603,9 @@ span#login_widget > .button .badge,
   overflow: auto;
   flex: 1;
 }
+.modal-header {
+  cursor: move;
+}
 @media (min-width: 768px) {
   .modal .modal-dialog {
     width: 700px;
@@ -8928,6 +9626,19 @@ span#login_widget > .button .badge,
   display: inline-block;
   margin-bottom: -4px;
 }
+[dir="rtl"] .center-nav form.pull-left {
+  float: right !important;
+  float: right;
+}
+[dir="rtl"] .center-nav .navbar-text {
+  float: right;
+}
+[dir="rtl"] .navbar-inner {
+  text-align: right;
+}
+[dir="rtl"] div.text-left {
+  text-align: right;
+}
 /*!
 *
 * IPython tree view
@@ -8944,34 +9655,42 @@ span#login_widget > .button .badge,
   margin: 0;
 }
 .alternate_upload input.fileinput {
-  text-align: center;
-  vertical-align: middle;
-  display: inline;
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  cursor: pointer;
   opacity: 0;
   z-index: 2;
-  width: 12ex;
-  margin-right: -12ex;
+}
+.alternate_upload .btn-xs > input.fileinput {
+  margin: -1px -5px;
 }
 .alternate_upload .btn-upload {
+  position: relative;
   height: 22px;
+}
+::-webkit-file-upload-button {
+  cursor: pointer;
 }
 /**
  * Primary styles
  *
  * Author: Jupyter Development Team
  */
-[dir="rtl"] #tabs li {
-  float: right;
-}
 ul#tabs {
   margin-bottom: 4px;
-}
-[dir="rtl"] ul#tabs {
-  margin-right: 0px;
 }
 ul#tabs a {
   padding-top: 6px;
   padding-bottom: 4px;
+}
+[dir="rtl"] ul#tabs.nav-tabs > li {
+  float: right;
+}
+[dir="rtl"] ul#tabs.nav.nav-tabs {
+  padding-right: 0;
 }
 ul.breadcrumb a:focus,
 ul.breadcrumb a:hover {
@@ -8991,15 +9710,13 @@ ul.breadcrumb span {
 .list_toolbar .tree-buttons {
   padding-top: 1px;
 }
-[dir="rtl"] .list_toolbar .tree-buttons {
+[dir="rtl"] .list_toolbar .tree-buttons .pull-right {
   float: left !important;
+  float: left;
 }
-[dir="rtl"] .list_toolbar .pull-right {
-  padding-top: 1px;
-  float: left !important;
-}
-[dir="rtl"] .list_toolbar .pull-left {
-  float: right !important;
+[dir="rtl"] .list_toolbar .col-sm-4,
+[dir="rtl"] .list_toolbar .col-sm-8 {
+  float: right;
 }
 .dynamic-buttons {
   padding-top: 3px;
@@ -9055,7 +9772,7 @@ ul.breadcrumb span {
 .list_item > div input {
   margin-right: 7px;
   margin-left: 14px;
-  vertical-align: baseline;
+  vertical-align: text-bottom;
   line-height: 22px;
   position: relative;
   top: -1px;
@@ -9065,6 +9782,9 @@ ul.breadcrumb span {
   margin-left: -1px;
   vertical-align: baseline;
   line-height: 22px;
+}
+[dir="rtl"] .list_item > div input {
+  margin-right: 0;
 }
 .new-file input[type=checkbox] {
   visibility: hidden;
@@ -9080,6 +9800,14 @@ ul.breadcrumb span {
   margin-left: 7px;
   line-height: 22px;
   vertical-align: baseline;
+}
+.item_modified {
+  margin-right: 7px;
+  margin-left: 7px;
+}
+[dir="rtl"] .item_modified.pull-right {
+  float: left !important;
+  float: left;
 }
 .item_buttons {
   line-height: 1em;
@@ -9108,6 +9836,14 @@ ul.breadcrumb span {
   margin-right: 7px;
   float: left;
 }
+[dir="rtl"] .item_buttons.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .item_buttons .kernel-name {
+  margin-left: 7px;
+  float: right;
+}
 .toolbar_info {
   height: 24px;
   line-height: 24px;
@@ -9133,18 +9869,32 @@ ul.breadcrumb span {
   background-color: transparent;
   font-weight: bold;
 }
+.sort_button {
+  display: inline-block;
+  padding-left: 7px;
+}
+[dir="rtl"] .sort_button.pull-right {
+  float: left !important;
+  float: left;
+}
 #tree-selector {
   padding-right: 0px;
-}
-[dir="rtl"] #tree-selector a {
-  float: right;
 }
 #button-select-all {
   min-width: 50px;
 }
+[dir="rtl"] #button-select-all.btn {
+  float: right ;
+}
 #select-all {
   margin-left: 7px;
   margin-right: 2px;
+  margin-top: 2px;
+  height: 16px;
+}
+[dir="rtl"] #select-all.pull-left {
+  float: right !important;
+  float: right;
 }
 .menu_icon {
   margin-right: 2px;
@@ -9162,6 +9912,12 @@ ul.breadcrumb span {
   -moz-osx-font-smoothing: grayscale;
   content: "\f114";
 }
+.folder_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.folder_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .folder_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -9178,6 +9934,12 @@ ul.breadcrumb span {
   content: "\f02d";
   position: relative;
   top: -1px;
+}
+.notebook_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.notebook_icon:before.fa-pull-right {
+  margin-left: .3em;
 }
 .notebook_icon:before.pull-left {
   margin-right: .3em;
@@ -9197,6 +9959,12 @@ ul.breadcrumb span {
   top: -1px;
   color: #5cb85c;
 }
+.running_notebook_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.running_notebook_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .running_notebook_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -9214,6 +9982,12 @@ ul.breadcrumb span {
   position: relative;
   top: -2px;
 }
+.file_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.file_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .file_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -9228,8 +10002,11 @@ ul#new-menu {
   left: auto;
   right: 0;
 }
-[dir="rtl"] #new-menu {
-  text-align: right;
+#new-menu .dropdown-header {
+  font-size: 10px;
+  border-bottom: 1px solid #e5e5e5;
+  padding: 0 0 3px;
+  margin: -3px 20px 0;
 }
 .kernel-menu-icon {
   padding-right: 12px;
@@ -9276,9 +10053,6 @@ ul#new-menu {
 #running .panel-group .panel .panel-body .list_container .list_item:last-child {
   border-bottom: 0px;
 }
-[dir="rtl"] #running .col-sm-8 {
-  float: right !important;
-}
 .delete-button {
   display: none;
 }
@@ -9286,6 +10060,12 @@ ul#new-menu {
   display: none;
 }
 .rename-button {
+  display: none;
+}
+.move-button {
+  display: none;
+}
+.download-button {
   display: none;
 }
 .shutdown-button {
@@ -9328,6 +10108,12 @@ ul#new-menu {
   -moz-osx-font-smoothing: grayscale;
   width: 20px;
 }
+.dirty-indicator.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator.fa-pull-right {
+  margin-left: .3em;
+}
 .dirty-indicator.pull-left {
   margin-right: .3em;
 }
@@ -9342,6 +10128,12 @@ ul#new-menu {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   width: 20px;
+}
+.dirty-indicator-dirty.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-dirty.fa-pull-right {
+  margin-left: .3em;
 }
 .dirty-indicator-dirty.pull-left {
   margin-right: .3em;
@@ -9358,6 +10150,12 @@ ul#new-menu {
   -moz-osx-font-smoothing: grayscale;
   width: 20px;
 }
+.dirty-indicator-clean.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean.fa-pull-right {
+  margin-left: .3em;
+}
 .dirty-indicator-clean.pull-left {
   margin-right: .3em;
 }
@@ -9372,6 +10170,12 @@ ul#new-menu {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: "\f00c";
+}
+.dirty-indicator-clean:before.fa-pull-left {
+  margin-right: .3em;
+}
+.dirty-indicator-clean:before.fa-pull-right {
+  margin-left: .3em;
 }
 .dirty-indicator-clean:before.pull-left {
   margin-right: .3em;
@@ -9417,14 +10221,132 @@ ul#new-menu {
     box-shadow: 0px 0px 12px 1px rgba(87, 87, 87, 0.2);
   }
 }
+.CodeMirror-dialog {
+  background-color: #fff;
+}
 /*!
 *
 * IPython notebook
 *
 */
-/* CSS font colors for translated ANSI colors. */
+/* CSS font colors for translated ANSI escape sequences */
+/* The color values are a mix of
+   http://www.xcolors.net/dl/baskerville-ivorylight and
+   http://www.xcolors.net/dl/euphrasia */
+.ansi-black-fg {
+  color: #3E424D;
+}
+.ansi-black-bg {
+  background-color: #3E424D;
+}
+.ansi-black-intense-fg {
+  color: #282C36;
+}
+.ansi-black-intense-bg {
+  background-color: #282C36;
+}
+.ansi-red-fg {
+  color: #E75C58;
+}
+.ansi-red-bg {
+  background-color: #E75C58;
+}
+.ansi-red-intense-fg {
+  color: #B22B31;
+}
+.ansi-red-intense-bg {
+  background-color: #B22B31;
+}
+.ansi-green-fg {
+  color: #00A250;
+}
+.ansi-green-bg {
+  background-color: #00A250;
+}
+.ansi-green-intense-fg {
+  color: #007427;
+}
+.ansi-green-intense-bg {
+  background-color: #007427;
+}
+.ansi-yellow-fg {
+  color: #DDB62B;
+}
+.ansi-yellow-bg {
+  background-color: #DDB62B;
+}
+.ansi-yellow-intense-fg {
+  color: #B27D12;
+}
+.ansi-yellow-intense-bg {
+  background-color: #B27D12;
+}
+.ansi-blue-fg {
+  color: #208FFB;
+}
+.ansi-blue-bg {
+  background-color: #208FFB;
+}
+.ansi-blue-intense-fg {
+  color: #0065CA;
+}
+.ansi-blue-intense-bg {
+  background-color: #0065CA;
+}
+.ansi-magenta-fg {
+  color: #D160C4;
+}
+.ansi-magenta-bg {
+  background-color: #D160C4;
+}
+.ansi-magenta-intense-fg {
+  color: #A03196;
+}
+.ansi-magenta-intense-bg {
+  background-color: #A03196;
+}
+.ansi-cyan-fg {
+  color: #60C6C8;
+}
+.ansi-cyan-bg {
+  background-color: #60C6C8;
+}
+.ansi-cyan-intense-fg {
+  color: #258F8F;
+}
+.ansi-cyan-intense-bg {
+  background-color: #258F8F;
+}
+.ansi-white-fg {
+  color: #C5C1B4;
+}
+.ansi-white-bg {
+  background-color: #C5C1B4;
+}
+.ansi-white-intense-fg {
+  color: #A1A6B2;
+}
+.ansi-white-intense-bg {
+  background-color: #A1A6B2;
+}
+.ansi-default-inverse-fg {
+  color: #FFFFFF;
+}
+.ansi-default-inverse-bg {
+  background-color: #000000;
+}
+.ansi-bold {
+  font-weight: bold;
+}
+.ansi-underline {
+  text-decoration: underline;
+}
+/* The following styles are deprecated an will be removed in a future version */
 .ansibold {
   font-weight: bold;
+}
+.ansi-inverse {
+  outline: 0.5px dotted;
 }
 /* use dark versions for foreground, to improve visibility */
 .ansiblack {
@@ -9503,12 +10425,20 @@ div.cell {
   /* This acts as a spacer between cells, that is outside the border */
   margin: 0px;
   outline: none;
-  border-left-width: 1px;
-  padding-left: 5px;
-  background: linear-gradient(to right, transparent -40px, transparent 1px, transparent 1px, transparent 100%);
+  position: relative;
+  overflow: visible;
+}
+div.cell:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: transparent;
 }
 div.cell.jupyter-soft-selected {
-  border-left-color: #90CAF9;
   border-left-color: #E3F2FD;
   border-left-width: 1px;
   padding-left: 5px;
@@ -9521,27 +10451,39 @@ div.cell.jupyter-soft-selected {
     border-color: transparent;
   }
 }
-div.cell.selected {
+div.cell.selected,
+div.cell.selected.jupyter-soft-selected {
   border-color: #ababab;
-  border-left-width: 0px;
-  padding-left: 6px;
-  background: linear-gradient(to right, #42A5F5 -40px, #42A5F5 5px, transparent 5px, transparent 100%);
+}
+div.cell.selected:before,
+div.cell.selected.jupyter-soft-selected:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: #42A5F5;
 }
 @media print {
-  div.cell.selected {
+  div.cell.selected,
+  div.cell.selected.jupyter-soft-selected {
     border-color: transparent;
   }
 }
-div.cell.selected.jupyter-soft-selected {
-  border-left-width: 0;
-  padding-left: 6px;
-  background: linear-gradient(to right, #42A5F5 -40px, #42A5F5 7px, #E3F2FD 7px, #E3F2FD 100%);
-}
 .edit_mode div.cell.selected {
   border-color: #66BB6A;
-  border-left-width: 0px;
-  padding-left: 6px;
-  background: linear-gradient(to right, #66BB6A -40px, #66BB6A 5px, transparent 5px, transparent 100%);
+}
+.edit_mode div.cell.selected:before {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  width: 5px;
+  height: calc(100% +  2px);
+  content: '';
+  background: #66BB6A;
 }
 @media print {
   .edit_mode div.cell.selected {
@@ -9737,7 +10679,9 @@ div.input_area > div.highlight > pre {
 .CodeMirror-lines {
   /* In CM2, this used to be 0.4em, but in CM3 it went to 4px. We need the em value because */
   /* we have set a different line-height and want this to scale with that. */
-  padding: 0.4em;
+  /* Note that this should set vertical padding only, since CodeMirror assumes
+       that horizontal padding will be set on CodeMirror pre */
+  padding: 0.4em 0;
 }
 .CodeMirror-linenumber {
   padding: 0 8px 0 4px;
@@ -9747,11 +10691,24 @@ div.input_area > div.highlight > pre {
   border-top-left-radius: 2px;
 }
 .CodeMirror pre {
-  /* In CM3 this went to 4px from 0 in CM2. We need the 0 value because of how we size */
-  /* .CodeMirror-lines */
-  padding: 0;
+  /* In CM3 this went to 4px from 0 in CM2. This sets horizontal padding only,
+    use .CodeMirror-lines for vertical */
+  padding: 0 0.4em;
   border: 0;
   border-radius: 0;
+}
+.CodeMirror-cursor {
+  border-left: 1.4px solid black;
+}
+@media screen and (min-width: 2138px) and (max-width: 4319px) {
+  .CodeMirror-cursor {
+    border-left: 2px solid black;
+  }
+}
+@media screen and (min-width: 4320px) {
+  .CodeMirror-cursor {
+    border-left: 4px solid black;
+  }
 }
 /*
 
@@ -10005,6 +10962,9 @@ div.output_area img.unconfined,
 div.output_area svg.unconfined {
   max-width: none;
 }
+div.output_area .mglyph > img {
+  max-width: none;
+}
 /* This is needed to protect the pre formating from global settings such
    as that of bootstrap */
 .output {
@@ -10043,7 +11003,7 @@ div.output_area svg.unconfined {
 }
 div.output_area pre {
   margin: 0;
-  padding: 0;
+  padding: 1px 0 1px 0;
   border: 0;
   vertical-align: baseline;
   color: black;
@@ -10203,39 +11163,35 @@ div.output_unrecognized a:hover {
 .rendered_html h6:first-child {
   margin-top: 1em;
 }
+.rendered_html ul:not(.list-inline),
+.rendered_html ol:not(.list-inline) {
+  padding-left: 2em;
+}
 .rendered_html ul {
   list-style: disc;
-  margin: 0em 2em;
-  padding-left: 0px;
 }
 .rendered_html ul ul {
   list-style: square;
-  margin: 0em 2em;
+  margin-top: 0;
 }
 .rendered_html ul ul ul {
   list-style: circle;
-  margin: 0em 2em;
 }
 .rendered_html ol {
   list-style: decimal;
-  margin: 0em 2em;
-  padding-left: 0px;
 }
 .rendered_html ol ol {
   list-style: upper-alpha;
-  margin: 0em 2em;
+  margin-top: 0;
 }
 .rendered_html ol ol ol {
   list-style: lower-alpha;
-  margin: 0em 2em;
 }
 .rendered_html ol ol ol ol {
   list-style: lower-roman;
-  margin: 0em 2em;
 }
 .rendered_html ol ol ol ol ol {
   list-style: decimal;
-  margin: 0em 2em;
 }
 .rendered_html * + ul {
   margin-top: 1em;
@@ -10249,14 +11205,23 @@ div.output_unrecognized a:hover {
 }
 .rendered_html pre {
   margin: 1em 2em;
+  padding: 0px;
+  background-color: #fff;
+}
+.rendered_html code {
+  background-color: #eff0f1;
+}
+.rendered_html p code {
+  padding: 1px 5px;
+}
+.rendered_html pre code {
+  background-color: #fff;
 }
 .rendered_html pre,
 .rendered_html code {
   border: 0;
-  background-color: #fff;
   color: #000;
   font-size: 100%;
-  padding: 0px;
 }
 .rendered_html blockquote {
   margin: 1em 2em;
@@ -10264,24 +11229,36 @@ div.output_unrecognized a:hover {
 .rendered_html table {
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid black;
+  border: none;
   border-collapse: collapse;
+  border-spacing: 0;
+  color: black;
+  font-size: 12px;
+  table-layout: fixed;
+}
+.rendered_html thead {
+  border-bottom: 1px solid black;
+  vertical-align: bottom;
 }
 .rendered_html tr,
 .rendered_html th,
 .rendered_html td {
-  border: 1px solid black;
-  border-collapse: collapse;
-  margin: 1em 2em;
-}
-.rendered_html td,
-.rendered_html th {
-  text-align: left;
+  text-align: right;
   vertical-align: middle;
-  padding: 4px;
+  padding: 0.5em 0.5em;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
+  border: none;
 }
 .rendered_html th {
   font-weight: bold;
+}
+.rendered_html tbody tr:nth-child(odd) {
+  background: #f5f5f5;
+}
+.rendered_html tbody tr:hover {
+  background: rgba(66, 165, 245, 0.2);
 }
 .rendered_html * + table {
   margin-top: 1em;
@@ -10308,6 +11285,15 @@ div.output_unrecognized a:hover {
 .rendered_html img.unconfined,
 .rendered_html svg.unconfined {
   max-width: none;
+}
+.rendered_html .alert {
+  margin-bottom: initial;
+}
+.rendered_html * + .alert {
+  margin-top: 1em;
+}
+[dir="rtl"] .rendered_html p {
+  text-align: right;
 }
 div.text_cell {
   /* Old browsers */
@@ -10362,8 +11348,17 @@ h6:hover .anchor-link {
   overflow-x: auto;
   overflow-y: hidden;
 }
+.text_cell.rendered .rendered_html tr,
+.text_cell.rendered .rendered_html th,
+.text_cell.rendered .rendered_html td {
+  max-width: none;
+}
 .text_cell.unrendered .text_cell_render {
   display: none;
+}
+.text_cell .dropzone .input_area {
+  border: 2px dashed #bababa;
+  margin: -1px;
 }
 .cm-header-1,
 .cm-header-2,
@@ -10500,6 +11495,28 @@ kbd {
   padding-top: 1px;
   padding-bottom: 1px;
 }
+.jupyter-keybindings {
+  padding: 1px;
+  line-height: 24px;
+  border-bottom: 1px solid gray;
+}
+.jupyter-keybindings input {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+.jupyter-keybindings i {
+  padding: 6px;
+}
+.well code {
+  background-color: #ffffff;
+  border-color: #ababab;
+  border-width: 1px;
+  border-style: solid;
+  padding: 2px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
 /* CSS for the cell toolbar */
 .celltoolbar {
   border: thin solid #CFCFCF;
@@ -10632,6 +11649,152 @@ select[multiple].celltoolbar select {
   margin-left: 5px;
   margin-right: 5px;
 }
+.tags_button_container {
+  width: 100%;
+  display: flex;
+}
+.tag-container {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  overflow: hidden;
+  position: relative;
+}
+.tag-container > * {
+  margin: 0 4px;
+}
+.remove-tag-btn {
+  margin-left: 4px;
+}
+.tags-input {
+  display: flex;
+}
+.cell-tag:last-child:after {
+  content: "";
+  position: absolute;
+  right: 0;
+  width: 40px;
+  height: 100%;
+  /* Fade to background color of cell toolbar */
+  background: linear-gradient(to right, rgba(0, 0, 0, 0), #EEE);
+}
+.tags-input > * {
+  margin-left: 4px;
+}
+.cell-tag,
+.tags-input input,
+.tags-input button {
+  display: block;
+  width: 100%;
+  height: 32px;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #555555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 1px;
+  box-shadow: none;
+  width: inherit;
+  font-size: inherit;
+  height: 22px;
+  line-height: 22px;
+  padding: 0px 4px;
+  display: inline-block;
+}
+.cell-tag:focus,
+.tags-input input:focus,
+.tags-input button:focus {
+  border-color: #66afe9;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+.cell-tag::-moz-placeholder,
+.tags-input input::-moz-placeholder,
+.tags-input button::-moz-placeholder {
+  color: #999;
+  opacity: 1;
+}
+.cell-tag:-ms-input-placeholder,
+.tags-input input:-ms-input-placeholder,
+.tags-input button:-ms-input-placeholder {
+  color: #999;
+}
+.cell-tag::-webkit-input-placeholder,
+.tags-input input::-webkit-input-placeholder,
+.tags-input button::-webkit-input-placeholder {
+  color: #999;
+}
+.cell-tag::-ms-expand,
+.tags-input input::-ms-expand,
+.tags-input button::-ms-expand {
+  border: 0;
+  background-color: transparent;
+}
+.cell-tag[disabled],
+.tags-input input[disabled],
+.tags-input button[disabled],
+.cell-tag[readonly],
+.tags-input input[readonly],
+.tags-input button[readonly],
+fieldset[disabled] .cell-tag,
+fieldset[disabled] .tags-input input,
+fieldset[disabled] .tags-input button {
+  background-color: #eeeeee;
+  opacity: 1;
+}
+.cell-tag[disabled],
+.tags-input input[disabled],
+.tags-input button[disabled],
+fieldset[disabled] .cell-tag,
+fieldset[disabled] .tags-input input,
+fieldset[disabled] .tags-input button {
+  cursor: not-allowed;
+}
+textarea.cell-tag,
+textarea.tags-input input,
+textarea.tags-input button {
+  height: auto;
+}
+select.cell-tag,
+select.tags-input input,
+select.tags-input button {
+  height: 30px;
+  line-height: 30px;
+}
+textarea.cell-tag,
+textarea.tags-input input,
+textarea.tags-input button,
+select[multiple].cell-tag,
+select[multiple].tags-input input,
+select[multiple].tags-input button {
+  height: auto;
+}
+.cell-tag,
+.tags-input button {
+  padding: 0px 4px;
+}
+.cell-tag {
+  background-color: #fff;
+  white-space: nowrap;
+}
+.tags-input input[type=text]:focus {
+  outline: none;
+  box-shadow: none;
+  border-color: #ccc;
+}
 .completions {
   position: absolute;
   z-index: 110;
@@ -10657,16 +11820,28 @@ select[multiple].celltoolbar select {
 .completions select option.context {
   color: #286090;
 }
-#kernel_logo_widget {
-  float: right !important;
-  float: right;
-}
 #kernel_logo_widget .current_kernel_logo {
   display: none;
   margin-top: -1px;
   margin-bottom: -1px;
   width: 32px;
   height: 32px;
+}
+[dir="rtl"] #kernel_logo_widget {
+  float: left !important;
+  float: left;
+}
+.modal .modal-body .move-path {
+  display: flex;
+  flex-direction: row;
+  justify-content: space;
+  align-items: center;
+}
+.modal .modal-body .move-path .server-root {
+  padding-right: 20px;
+}
+.modal .modal-body .move-path .path-input {
+  flex: 1;
 }
 #menubar {
   box-sizing: border-box;
@@ -10688,11 +11863,41 @@ select[multiple].celltoolbar select {
 #menubar .navbar-collapse {
   clear: left;
 }
+[dir="rtl"] #menubar .navbar-toggle {
+  float: right;
+}
+[dir="rtl"] #menubar .navbar-collapse {
+  clear: right;
+}
+[dir="rtl"] #menubar .navbar-nav {
+  float: right;
+}
+[dir="rtl"] #menubar .nav {
+  padding-right: 0px;
+}
+[dir="rtl"] #menubar .navbar-nav > li {
+  float: right;
+}
+[dir="rtl"] #menubar .navbar-right {
+  float: left !important;
+}
+[dir="rtl"] ul.dropdown-menu {
+  text-align: right;
+  left: auto;
+}
+[dir="rtl"] ul#new-menu.dropdown-menu {
+  right: auto;
+  left: 0;
+}
 .nav-wrapper {
   border-bottom: 1px solid #e7e7e7;
 }
 i.menu-icon {
   padding-top: 4px;
+}
+[dir="rtl"] i.menu-icon.pull-right {
+  float: left !important;
+  float: left;
 }
 ul#help_menu li a {
   overflow: hidden;
@@ -10700,6 +11905,17 @@ ul#help_menu li a {
 }
 ul#help_menu li a i {
   margin-right: -1.2em;
+}
+[dir="rtl"] ul#help_menu li a {
+  padding-left: 2.2em;
+}
+[dir="rtl"] ul#help_menu li a i {
+  margin-right: 0;
+  margin-left: -1.2em;
+}
+[dir="rtl"] ul#help_menu li a i.pull-right {
+  float: left !important;
+  float: left;
 }
 .dropdown-submenu {
   position: relative;
@@ -10709,6 +11925,10 @@ ul#help_menu li a i {
   left: 100%;
   margin-top: -6px;
   margin-left: -1px;
+}
+[dir="rtl"] .dropdown-submenu > .dropdown-menu {
+  right: 100%;
+  margin-right: -1px;
 }
 .dropdown-submenu:hover > .dropdown-menu {
   display: block;
@@ -10727,11 +11947,23 @@ ul#help_menu li a i {
   margin-top: 2px;
   margin-right: -10px;
 }
+.dropdown-submenu > a:after.fa-pull-left {
+  margin-right: .3em;
+}
+.dropdown-submenu > a:after.fa-pull-right {
+  margin-left: .3em;
+}
 .dropdown-submenu > a:after.pull-left {
   margin-right: .3em;
 }
 .dropdown-submenu > a:after.pull-right {
   margin-left: .3em;
+}
+[dir="rtl"] .dropdown-submenu > a:after {
+  float: left;
+  content: "\f0d9";
+  margin-right: 0;
+  margin-left: -10px;
 }
 .dropdown-submenu:hover > a:after {
   color: #262626;
@@ -10748,6 +11980,10 @@ ul#help_menu li a i {
   float: right;
   z-index: 10;
 }
+[dir="rtl"] #notification_area {
+  float: left !important;
+  float: left;
+}
 .indicator_area {
   float: right !important;
   float: right;
@@ -10758,6 +11994,10 @@ ul#help_menu li a i {
   z-index: 10;
   text-align: center;
   width: auto;
+}
+[dir="rtl"] .indicator_area {
+  float: left !important;
+  float: left;
 }
 #kernel_indicator {
   float: right !important;
@@ -10775,6 +12015,12 @@ ul#help_menu li a i {
   padding-left: 5px;
   padding-right: 5px;
 }
+[dir="rtl"] #kernel_indicator {
+  float: left !important;
+  float: left;
+  border-left: 0;
+  border-right: 1px solid;
+}
 #modal_indicator {
   float: right !important;
   float: right;
@@ -10785,6 +12031,10 @@ ul#help_menu li a i {
   z-index: 10;
   text-align: center;
   width: auto;
+}
+[dir="rtl"] #modal_indicator {
+  float: left !important;
+  float: left;
 }
 #readonly-indicator {
   float: right !important;
@@ -10815,6 +12065,12 @@ ul#help_menu li a i {
   -moz-osx-font-smoothing: grayscale;
   content: "\f040";
 }
+.edit_mode .modal_indicator:before.fa-pull-left {
+  margin-right: .3em;
+}
+.edit_mode .modal_indicator:before.fa-pull-right {
+  margin-left: .3em;
+}
 .edit_mode .modal_indicator:before.pull-left {
   margin-right: .3em;
 }
@@ -10829,6 +12085,12 @@ ul#help_menu li a i {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: ' ';
+}
+.command_mode .modal_indicator:before.fa-pull-left {
+  margin-right: .3em;
+}
+.command_mode .modal_indicator:before.fa-pull-right {
+  margin-left: .3em;
 }
 .command_mode .modal_indicator:before.pull-left {
   margin-right: .3em;
@@ -10845,6 +12107,12 @@ ul#help_menu li a i {
   -moz-osx-font-smoothing: grayscale;
   content: "\f10c";
 }
+.kernel_idle_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_idle_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .kernel_idle_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -10859,6 +12127,12 @@ ul#help_menu li a i {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: "\f111";
+}
+.kernel_busy_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_busy_icon:before.fa-pull-right {
+  margin-left: .3em;
 }
 .kernel_busy_icon:before.pull-left {
   margin-right: .3em;
@@ -10875,6 +12149,12 @@ ul#help_menu li a i {
   -moz-osx-font-smoothing: grayscale;
   content: "\f1e2";
 }
+.kernel_dead_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_dead_icon:before.fa-pull-right {
+  margin-left: .3em;
+}
 .kernel_dead_icon:before.pull-left {
   margin-right: .3em;
 }
@@ -10889,6 +12169,12 @@ ul#help_menu li a i {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   content: "\f127";
+}
+.kernel_disconnected_icon:before.fa-pull-left {
+  margin-right: .3em;
+}
+.kernel_disconnected_icon:before.fa-pull-right {
+  margin-left: .3em;
 }
 .kernel_disconnected_icon:before.pull-left {
   margin-right: .3em;
@@ -11279,27 +12565,46 @@ div#pager .ui-resizable-handle::after {
   flex: 1;
 }
 span.save_widget {
-  margin-top: 6px;
+  height: 30px;
+  margin-top: 4px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: baseline;
+  width: 50%;
+  flex: 1;
 }
 span.save_widget span.filename {
-  height: 1em;
+  height: 100%;
   line-height: 1em;
-  padding: 3px;
   margin-left: 16px;
   border: none;
   font-size: 146.5%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
   border-radius: 2px;
 }
 span.save_widget span.filename:hover {
   background-color: #e6e6e6;
 }
+[dir="rtl"] span.save_widget.pull-left {
+  float: right !important;
+  float: right;
+}
+[dir="rtl"] span.save_widget span.filename {
+  margin-left: 0;
+  margin-right: 16px;
+}
 span.checkpoint_status,
 span.autosave_status {
   font-size: small;
+  white-space: nowrap;
+  padding: 0 5px;
 }
 @media (max-width: 767px) {
   span.save_widget {
     font-size: small;
+    padding: 0 0 0 5px;
   }
   span.checkpoint_status,
   span.autosave_status {
@@ -11343,6 +12648,9 @@ span.autosave_status {
   margin-top: 0px;
   margin-left: 5px;
 }
+.toolbar-btn-label {
+  margin-left: 6px;
+}
 #maintoolbar {
   margin-bottom: -3px;
   margin-top: -8px;
@@ -11362,6 +12670,10 @@ span.autosave_status {
 }
 .select-xs {
   height: 24px;
+}
+[dir="rtl"] .btn-group > .btn,
+.btn-group-vertical > .btn {
+  float: right;
 }
 .pulse,
 .dropdown-menu > li > a.pulse,
@@ -11512,6 +12824,10 @@ ul.typeahead-list i {
   margin-left: -10px;
   width: 18px;
 }
+[dir="rtl"] ul.typeahead-list i {
+  margin-left: 0;
+  margin-right: -10px;
+}
 ul.typeahead-list {
   max-height: 80vh;
   overflow: auto;
@@ -11520,6 +12836,13 @@ ul.typeahead-list > li > a {
   /** Firefox bug **/
   /* see https://github.com/jupyter/notebook/issues/559 */
   white-space: normal;
+}
+ul.typeahead-list  > li > a.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .typeahead-list {
+  text-align: right;
 }
 .cmd-palette .modal-body {
   padding: 7px;
@@ -11531,10 +12854,19 @@ ul.typeahead-list > li > a {
   outline: none;
 }
 .no-shortcut {
-  display: none;
+  min-width: 20px;
+  color: transparent;
+}
+[dir="rtl"] .no-shortcut.pull-right {
+  float: left !important;
+  float: left;
+}
+[dir="rtl"] .command-shortcut.pull-right {
+  float: left !important;
+  float: left;
 }
 .command-shortcut:before {
-  content: "(command)";
+  content: "(command mode)";
   padding-right: 3px;
   color: #777777;
 }
@@ -11543,6 +12875,10 @@ ul.typeahead-list > li > a {
   padding-right: 3px;
   color: #777777;
 }
+[dir="rtl"] .edit-shortcut.pull-right {
+  float: left !important;
+  float: left;
+}
 #find-and-replace #replace-preview .match,
 #find-and-replace #replace-preview .insert {
   background-color: #BBDEFB;
@@ -11550,6 +12886,12 @@ ul.typeahead-list > li > a {
   border-style: solid;
   border-width: 1px;
   border-radius: 0px;
+}
+[dir="ltr"] #find-and-replace .input-group-btn + .form-control {
+  border-left: none;
+}
+[dir="rtl"] #find-and-replace .input-group-btn + .form-control {
+  border-right: none;
 }
 #find-and-replace #replace-preview .replace .match {
   background-color: #FFCDD2;
@@ -11776,20 +13118,19 @@ div#notebook {
 <div class="prompt input_prompt">In&nbsp;[1]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">from</span> <span class="nn">citrination_client</span> <span class="kn">import</span> <span class="n">CitrinationClient</span>
-<span class="kn">from</span> <span class="nn">os</span> <span class="kn">import</span> <span class="n">environ</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">citrination_client</span> <span class="k">import</span> <span class="n">CitrinationClient</span>
+<span class="kn">from</span> <span class="nn">os</span> <span class="k">import</span> <span class="n">environ</span>
 
 <span class="n">client</span> <span class="o">=</span> <span class="n">CitrinationClient</span><span class="p">(</span><span class="n">environ</span><span class="p">[</span><span class="s1">&#39;CITRINATION_API_KEY&#39;</span><span class="p">],</span> <span class="s1">&#39;https://citrination.com&#39;</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="Introduction-to-Queries">Introduction to Queries<a class="anchor-link" href="#Introduction-to-Queries">&#182;</a></h1><p>Queries allow you to search and download PIFs from Citrination.  By basing scripts on queries intead of local files, you can:</p>
 <ol>
@@ -11802,8 +13143,7 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Query-interfaces">Query interfaces<a class="anchor-link" href="#Query-interfaces">&#182;</a></h2><p>There are multiple interfaces to a unified backend based on elastic search:</p>
 <ol>
@@ -11817,8 +13157,7 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="PifSystemReturningQuery"><code>PifSystemReturningQuery</code><a class="anchor-link" href="#PifSystemReturningQuery">&#182;</a></h2><p>Each search and download request is stored in a query object: the <code>PifSystemReturningQuery</code>.</p>
 
@@ -11826,8 +13165,7 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>A PifQuery is structured in the following hierarchical way:</p>
 
@@ -11847,10 +13185,9 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<p>If you are working through the notebooks in the order they are presented on our <a href="https://citrination.org/learn/api-examples/">API Examples</a> site, use the <code>dataset_id</code> from the previous Importing VASP calculations notebook in the query below.</p>
+<p>If you are working through the notebooks in the order they are presented in our <a href="README.md">README</a>, use the <code>dataset_id</code> from the previous Importing VASP calculations notebook in the query below.</p>
 <p>Otherwise, we can start with the <a href="https://citrination.com/datasets/1160/show_search">Bandgaps Dataset</a>, but feel free to use any public dataset.</p>
 
 </div>
@@ -11858,12 +13195,12 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[2]:</div>
+<div class="prompt input_prompt">In&nbsp;[3]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">from</span> <span class="nn">citrination_client</span> <span class="kn">import</span> <span class="n">PifSystemReturningQuery</span><span class="p">,</span> <span class="n">PifSystemQuery</span>
-<span class="kn">from</span> <span class="nn">citrination_client</span> <span class="kn">import</span> <span class="n">DataQuery</span><span class="p">,</span> <span class="n">DatasetQuery</span><span class="p">,</span> <span class="n">ChemicalFieldQuery</span><span class="p">,</span> <span class="n">ChemicalFilter</span><span class="p">,</span> <span class="n">Filter</span>
-<span class="kn">from</span> <span class="nn">citrination_client</span> <span class="kn">import</span> <span class="n">PropertyQuery</span><span class="p">,</span> <span class="n">FieldQuery</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">citrination_client</span> <span class="k">import</span> <span class="n">PifSystemReturningQuery</span><span class="p">,</span> <span class="n">PifSystemQuery</span>
+<span class="kn">from</span> <span class="nn">citrination_client</span> <span class="k">import</span> <span class="n">DataQuery</span><span class="p">,</span> <span class="n">DatasetQuery</span><span class="p">,</span> <span class="n">ChemicalFieldQuery</span><span class="p">,</span> <span class="n">ChemicalFilter</span><span class="p">,</span> <span class="n">Filter</span>
+<span class="kn">from</span> <span class="nn">citrination_client</span> <span class="k">import</span> <span class="n">PropertyQuery</span><span class="p">,</span> <span class="n">FieldQuery</span>
 
 <span class="c1">#change dataset id below</span>
 <span class="n">my_dataset_id</span> <span class="o">=</span> <span class="mi">154987</span>
@@ -11874,11 +13211,11 @@ div#notebook {
                                             <span class="n">dataset</span><span class="o">=</span><span class="n">DatasetQuery</span><span class="p">(</span>
                                                 <span class="nb">id</span><span class="o">=</span><span class="n">Filter</span><span class="p">(</span><span class="n">equal</span><span class="o">=</span><span class="nb">str</span><span class="p">(</span><span class="n">my_dataset_id</span><span class="p">))</span>
                                          <span class="p">)))</span>
-<span class="n">query_result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query_dataset</span><span class="p">)</span>
-<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Found {} PIFs in dataset {}&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">query_result</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">,</span> <span class="n">my_dataset_id</span><span class="p">))</span>
+<span class="n">query_result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query_dataset</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Found </span><span class="si">{}</span><span class="s2"> PIFs in dataset </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">query_result</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">,</span> <span class="n">my_dataset_id</span><span class="p">))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -11888,7 +13225,7 @@ div#notebook {
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
@@ -11902,61 +13239,9 @@ div#notebook {
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The result contains the matching PIFs:</p>
-
-</div>
-</div>
-</div>
-<div class="cell border-box-sizing code_cell rendered">
-<div class="input">
-<div class="prompt input_prompt">In&nbsp;[3]:</div>
-<div class="inner_cell">
-    <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">from</span> <span class="nn">pypif.pif</span> <span class="kn">import</span> <span class="n">dumps</span>
-<span class="n">pifs</span> <span class="o">=</span> <span class="p">[</span><span class="n">x</span><span class="o">.</span><span class="n">system</span> <span class="k">for</span> <span class="n">x</span> <span class="ow">in</span> <span class="n">query_result</span><span class="o">.</span><span class="n">hits</span><span class="p">]</span>
-<span class="k">print</span><span class="p">(</span><span class="n">dumps</span><span class="p">(</span><span class="n">pifs</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">indent</span><span class="o">=</span><span class="mi">2</span><span class="p">)[:</span><span class="mi">550</span><span class="p">])</span>
-</pre></div>
-
-</div>
-</div>
-</div>
-
-<div class="output_wrapper">
-<div class="output">
-
-
-<div class="output_area">
-
-<div class="prompt"></div>
-
-
-<div class="output_subarea output_stream output_stdout output_text">
-<pre>{
-  &#34;category&#34;: &#34;system.chemical&#34;, 
-  &#34;uid&#34;: &#34;749884A0B1FEF61DBE5C053C25AD1A90&#34;, 
-  &#34;tags&#34;: [
-    &#34;my_first_upload&#34;
-  ], 
-  &#34;qualityReport&#34;: {
-    &#34;body&#34;: &#34;&#34;, 
-    &#34;name&#34;: &#34;&#34;, 
-    &#34;postamble&#34;: &#34;nowrap Summary:       Number of tests:   6\n                critical error:   0\n                         error:   0\n               serious warning:   0\n                       warning:   2\n                       caution:   0\n                recommendation:   1\n                   information:   1\n                       comment:   0\n               
-</pre>
-</div>
-</div>
-
-</div>
-</div>
-
-</div>
-<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html">
-<p>A <code>simple_chemical_search</code> query using the citrination client can accept lists of datasets to bring in data from collaborators:</p>
 
 </div>
 </div>
@@ -11966,15 +13251,12 @@ div#notebook {
 <div class="prompt input_prompt">In&nbsp;[4]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">my_dataset_id</span> <span class="o">=</span> <span class="mi">154987</span><span class="p">;</span> <span class="n">another_dataset_id</span> <span class="o">=</span> <span class="mi">1160</span>
-
-<span class="n">query_result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">simple_chemical_search</span><span class="p">(</span><span class="n">include_datasets</span><span class="o">=</span><span class="p">[</span><span class="n">my_dataset_id</span><span class="p">,</span> <span class="n">another_dataset_id</span><span class="p">],</span> <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">)</span>
-<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Found {} PIFs in datasets {} and {}&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
-        <span class="n">query_result</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">,</span> <span class="n">my_dataset_id</span><span class="p">,</span> <span class="n">another_dataset_id</span>
-    <span class="p">))</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">pypif.pif</span> <span class="k">import</span> <span class="n">dumps</span>
+<span class="n">pifs</span> <span class="o">=</span> <span class="p">[</span><span class="n">x</span><span class="o">.</span><span class="n">system</span> <span class="k">for</span> <span class="n">x</span> <span class="ow">in</span> <span class="n">query_result</span><span class="o">.</span><span class="n">hits</span><span class="p">]</span>
+<span class="nb">print</span><span class="p">(</span><span class="n">dumps</span><span class="p">(</span><span class="n">pifs</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">indent</span><span class="o">=</span><span class="mi">2</span><span class="p">)[:</span><span class="mi">550</span><span class="p">])</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -11984,11 +13266,19 @@ div#notebook {
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>Found 1451 PIFs in datasets 154987 and 1160
+<pre>{
+  &#34;tags&#34;: [
+    &#34;my_first_upload&#34;
+  ],
+  &#34;category&#34;: &#34;system.chemical&#34;,
+  &#34;qualityReport&#34;: {
+    &#34;body&#34;: &#34;&#34;,
+    &#34;name&#34;: &#34;&#34;,
+    &#34;postamble&#34;: &#34;nowrap Summary:       Number of tests:   6\n                critical error:   0\n                         error:   0\n               serious warning:   0\n                       warning:   2\n                       caution:   0\n                recommendation:   1\n                   information:   1\n                       comment:   0\n                            ok:   2\n                not applicab
 </pre>
 </div>
 </div>
@@ -11998,8 +13288,52 @@ div#notebook {
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>A <code>simple_chemical_search</code> query using the citrination client can accept lists of datasets to bring in data from collaborators:</p>
+
 </div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[6]:</div>
 <div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">my_dataset_id</span> <span class="o">=</span> <span class="mi">154987</span><span class="p">;</span> <span class="n">another_dataset_id</span> <span class="o">=</span> <span class="mi">1160</span>
+
+<span class="n">query</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">generate_simple_chemical_query</span><span class="p">(</span><span class="n">include_datasets</span><span class="o">=</span><span class="p">[</span><span class="n">my_dataset_id</span><span class="p">,</span> <span class="n">another_dataset_id</span><span class="p">],</span> <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">)</span>
+<span class="n">retuls</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Found </span><span class="si">{}</span><span class="s2"> PIFs in datasets </span><span class="si">{}</span><span class="s2"> and </span><span class="si">{}</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span>
+        <span class="n">query_result</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">,</span> <span class="n">my_dataset_id</span><span class="p">,</span> <span class="n">another_dataset_id</span>
+    <span class="p">))</span>
+</pre></div>
+
+    </div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+    <div class="prompt"></div>
+
+
+<div class="output_subarea output_stream output_stdout output_text">
+<pre>Found 2 PIFs in datasets 154987 and 1160
+</pre>
+</div>
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="Advanced-Queries">Advanced Queries<a class="anchor-link" href="#Advanced-Queries">&#182;</a></h1><p>Writing analysis and post-processing on top of PIFs lets us:</p>
 <ol>
@@ -12011,8 +13345,7 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Let's actually do that!</p>
 
@@ -12020,8 +13353,7 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Real-example:-phase-stability-diagram">Real example: phase stability diagram<a class="anchor-link" href="#Real-example:-phase-stability-diagram">&#182;</a></h2><p>There are surely more Al-Cu binaries on Citrination.  We will:</p>
 <ol>
@@ -12035,8 +13367,7 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Search-for-relevant-data">Search for relevant data<a class="anchor-link" href="#Search-for-relevant-data">&#182;</a></h2><p>The exploratory search is usually best done on the website.  Tips and tricks:</p>
 <ul>
@@ -12048,8 +13379,7 @@ div#notebook {
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Adding-filters-to-the-query">Adding filters to the query<a class="anchor-link" href="#Adding-filters-to-the-query">&#182;</a></h2><p>Now that we are querying beyond just our data, we need to filter down to records that contain Al-Cu energies.</p>
 <h3 id="Filter-by-chemical-formula">Filter by chemical formula<a class="anchor-link" href="#Filter-by-chemical-formula">&#182;</a></h3><ol>
@@ -12062,10 +13392,10 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[5]:</div>
+<div class="prompt input_prompt">In&nbsp;[7]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="c1">#filtering over a known dataset by formula=&#39;CdTe&#39;</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="c1">#filtering over a known dataset by formula=&#39;CdTe&#39;</span>
 
 <span class="n">res</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">PifSystemReturningQuery</span><span class="p">(</span>
             <span class="n">size</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span>
@@ -12077,10 +13407,10 @@ div#notebook {
                     <span class="n">chemical_formula</span><span class="o">=</span><span class="n">ChemicalFieldQuery</span><span class="p">(</span>
                         <span class="nb">filter</span><span class="o">=</span><span class="n">ChemicalFilter</span><span class="p">(</span>
                             <span class="n">equal</span><span class="o">=</span><span class="s1">&#39;AlxCuy&#39;</span><span class="p">))))))</span>
-<span class="k">print</span><span class="p">(</span><span class="n">res</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="n">res</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12090,7 +13420,7 @@ div#notebook {
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
@@ -12105,21 +13435,21 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[6]:</div>
+<div class="prompt input_prompt">In&nbsp;[9]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="c1">#filtering by formula=&#39;AlxCuy&#39;</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="c1">#filtering by formula=&#39;AlxCuy&#39;</span>
 
 <span class="n">query</span> <span class="o">=</span> <span class="n">PifSystemReturningQuery</span><span class="p">(</span>
-            <span class="n">size</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span>
+            <span class="n">size</span><span class="o">=</span><span class="mi">10</span><span class="p">,</span>
             <span class="n">query</span><span class="o">=</span><span class="n">DataQuery</span><span class="p">(</span>
                 <span class="n">simple</span><span class="o">=</span><span class="s1">&#39;AlxCuy&#39;</span><span class="p">))</span>
 
-<span class="n">query_result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
-<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Found {} PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">query_result</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
+<span class="n">query_result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Found </span><span class="si">{}</span><span class="s2"> PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">query_result</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12129,11 +13459,11 @@ div#notebook {
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>Found 133 PIFs
+<pre>Found 139 PIFs
 </pre>
 </div>
 </div>
@@ -12143,8 +13473,7 @@ div#notebook {
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Filter-by-property">Filter by property<a class="anchor-link" href="#Filter-by-property">&#182;</a></h3><p>We can do quick filtered searches with <code>citrination_client.simple_chemical_search</code>. It returns a <code>PifSearchResult</code> object as before, but with useful filter flags. See the docs for more info.</p>
 
@@ -12153,17 +13482,19 @@ div#notebook {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[7]:</div>
+<div class="prompt input_prompt">In&nbsp;[11]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">quicksearch1</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">simple_chemical_search</span><span class="p">(</span><span class="n">property_name</span><span class="o">=</span><span class="s1">&#39;Formation Energy&#39;</span><span class="p">,</span> <span class="n">chemical_formula</span><span class="o">=</span><span class="s1">&#39;AlxCuy&#39;</span><span class="p">,</span> <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">)</span>
-<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Found {} PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">quicksearch1</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">query</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">generate_simple_chemical_query</span><span class="p">(</span><span class="n">property_name</span><span class="o">=</span><span class="s1">&#39;Formation Energy&#39;</span><span class="p">,</span> <span class="n">chemical_formula</span><span class="o">=</span><span class="s1">&#39;AlxCuy&#39;</span><span class="p">,</span> <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">)</span>
+<span class="n">quicksearch1</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Found </span><span class="si">{}</span><span class="s2"> PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">quicksearch1</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
 
-<span class="n">quicksearch2</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">simple_chemical_search</span><span class="p">(</span><span class="n">property_name</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;Formation Energy&#39;</span><span class="p">,</span> <span class="s1">&#39;Enthalpy of Formation&#39;</span><span class="p">],</span> <span class="n">chemical_formula</span><span class="o">=</span><span class="s1">&#39;AlxCuy&#39;</span><span class="p">,</span> <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">)</span>
-<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Found {} PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">quicksearch2</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
+<span class="n">query</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">generate_simple_chemical_query</span><span class="p">(</span><span class="n">property_name</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;Formation Energy&#39;</span><span class="p">,</span> <span class="s1">&#39;Enthalpy of Formation&#39;</span><span class="p">],</span> <span class="n">chemical_formula</span><span class="o">=</span><span class="s1">&#39;AlxCuy&#39;</span><span class="p">,</span> <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">)</span>
+<span class="n">quicksearch2</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Found </span><span class="si">{}</span><span class="s2"> PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">quicksearch2</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12173,7 +13504,7 @@ div#notebook {
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
@@ -12189,14 +13520,14 @@ Found 16 PIFs
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[8]:</div>
+<div class="prompt input_prompt">In&nbsp;[12]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">from</span> <span class="nn">pypif.pif</span> <span class="kn">import</span> <span class="n">dumps</span>
-<span class="k">print</span><span class="p">(</span><span class="n">dumps</span><span class="p">(</span><span class="n">quicksearch1</span><span class="o">.</span><span class="n">hits</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span><span class="o">.</span><span class="n">system</span><span class="p">,</span> <span class="n">indent</span><span class="o">=</span><span class="mi">2</span><span class="p">))</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">pypif.pif</span> <span class="k">import</span> <span class="n">dumps</span>
+<span class="nb">print</span><span class="p">(</span><span class="n">dumps</span><span class="p">(</span><span class="n">quicksearch1</span><span class="o">.</span><span class="n">hits</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span><span class="o">.</span><span class="n">system</span><span class="p">,</span> <span class="n">indent</span><span class="o">=</span><span class="mi">2</span><span class="p">))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12206,42 +13537,42 @@ Found 16 PIFs
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>{
-  &#34;category&#34;: &#34;system.chemical&#34;, 
-  &#34;chemicalFormula&#34;: &#34;CuAl2&#34;, 
+  &#34;category&#34;: &#34;system.chemical&#34;,
   &#34;references&#34;: [
     {
       &#34;doi&#34;: &#34;10.1016/j.commatsci.2012.02.002&#34;
-    }, 
+    },
     {
       &#34;doi&#34;: &#34;10.1016/j.commatsci.2012.02.005&#34;
     }
-  ], 
-  &#34;uid&#34;: &#34;5CA6B3488E258DB2E0A73ADDA2F97C4D&#34;, 
+  ],
+  &#34;uid&#34;: &#34;5CA6B3488E258DB2E0A73ADDA2F97C4D&#34;,
   &#34;properties&#34;: [
     {
+      &#34;name&#34;: &#34;Structure designation&#34;,
       &#34;scalars&#34;: [
         {
           &#34;value&#34;: &#34;CaF[2]&#34;
         }
-      ], 
-      &#34;name&#34;: &#34;Structure designation&#34;
-    }, 
+      ]
+    },
     {
+      &#34;name&#34;: &#34;Formation energy&#34;,
       &#34;scalars&#34;: [
         {
           &#34;value&#34;: &#34;-0.1799&#34;
         }
-      ], 
-      &#34;dataType&#34;: &#34;COMPUTATIONAL&#34;, 
-      &#34;units&#34;: &#34;eV/atom&#34;, 
-      &#34;name&#34;: &#34;Formation energy&#34;
+      ],
+      &#34;units&#34;: &#34;eV/atom&#34;,
+      &#34;dataType&#34;: &#34;COMPUTATIONAL&#34;
     }
-  ]
+  ],
+  &#34;chemicalFormula&#34;: &#34;CuAl2&#34;
 }
 </pre>
 </div>
@@ -12252,8 +13583,7 @@ Found 16 PIFs
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Extract-data-from-results-using-the-query-language">Extract data from results using the query language<a class="anchor-link" href="#Extract-data-from-results-using-the-query-language">&#182;</a></h2><p>Multiple sources typically use multiple internal formats.  The query language is smart about crawling the PIFs for properties with the right names, while <code>pypif</code> is not.  Fortunately, you can use the query language to do data extraction as well!</p>
 
@@ -12261,8 +13591,7 @@ Found 16 PIFs
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Using-extract_as">Using <code>extract_as</code><a class="anchor-link" href="#Using-extract_as">&#182;</a></h3>
 </div>
@@ -12270,10 +13599,10 @@ Found 16 PIFs
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[9]:</div>
+<div class="prompt input_prompt">In&nbsp;[13]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">query</span> <span class="o">=</span> <span class="n">PifSystemReturningQuery</span><span class="p">(</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">query</span> <span class="o">=</span> <span class="n">PifSystemReturningQuery</span><span class="p">(</span>
             <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">,</span>
             <span class="n">query</span><span class="o">=</span><span class="n">DataQuery</span><span class="p">(</span>
                 <span class="n">system</span><span class="o">=</span><span class="n">PifSystemQuery</span><span class="p">(</span>
@@ -12290,12 +13619,12 @@ Found 16 PIFs
                 <span class="p">)</span>
             <span class="p">))</span>
 
-<span class="n">res</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
-<span class="k">print</span><span class="p">(</span><span class="s2">&quot;Found {} PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">res</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
-<span class="k">print</span><span class="p">([</span><span class="n">x</span><span class="o">.</span><span class="n">extracted</span> <span class="k">for</span> <span class="n">x</span> <span class="ow">in</span> <span class="n">res</span><span class="o">.</span><span class="n">hits</span><span class="p">][</span><span class="mi">0</span><span class="p">:</span><span class="mi">2</span><span class="p">])</span>
+<span class="n">res</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
+<span class="nb">print</span><span class="p">(</span><span class="s2">&quot;Found </span><span class="si">{}</span><span class="s2"> PIFs&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="n">res</span><span class="o">.</span><span class="n">total_num_hits</span><span class="p">))</span>
+<span class="nb">print</span><span class="p">([</span><span class="n">x</span><span class="o">.</span><span class="n">extracted</span> <span class="k">for</span> <span class="n">x</span> <span class="ow">in</span> <span class="n">res</span><span class="o">.</span><span class="n">hits</span><span class="p">][</span><span class="mi">0</span><span class="p">:</span><span class="mi">2</span><span class="p">])</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12305,12 +13634,12 @@ Found 16 PIFs
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Found 16 PIFs
-[{u&#39;formula&#39;: u&#39;Cu3Al&#39;, u&#39;formation_enthalpy&#39;: u&#39;-0.1889&#39;}, {u&#39;formula&#39;: u&#39;CuAl2&#39;, u&#39;formation_enthalpy&#39;: u&#39;-0.1799&#39;}]
+[{&#39;formation_enthalpy&#39;: &#39;-0.1889&#39;, &#39;formula&#39;: &#39;Cu3Al&#39;}, {&#39;formation_enthalpy&#39;: &#39;-0.1799&#39;, &#39;formula&#39;: &#39;CuAl2&#39;}]
 </pre>
 </div>
 </div>
@@ -12320,8 +13649,7 @@ Found 16 PIFs
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>A few notes:</p>
 <ul>
@@ -12333,8 +13661,7 @@ Found 16 PIFs
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h2 id="Real-example:-phase-stability-diagram">Real example: phase stability diagram<a class="anchor-link" href="#Real-example:-phase-stability-diagram">&#182;</a></h2><p>Let's create an Al-Cu phase diagram and add these points.</p>
 
@@ -12342,8 +13669,7 @@ Found 16 PIFs
 </div>
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>We'll start with some sample DFT data and create pifs out of the samples. Then, we'll add the new points found in our query above.</p>
 
@@ -12352,11 +13678,11 @@ Found 16 PIFs
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[10]:</div>
+<div class="prompt input_prompt">In&nbsp;[14]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">os</span>
-<span class="kn">from</span> <span class="nn">dfttopif</span> <span class="kn">import</span> <span class="n">directory_to_pif</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">os</span>
+<span class="kn">from</span> <span class="nn">dfttopif</span> <span class="k">import</span> <span class="n">directory_to_pif</span>
 
 <span class="n">Cu_pif</span> <span class="o">=</span> <span class="n">directory_to_pif</span><span class="p">(</span><span class="s2">&quot;./example_data/Cu.cF4&quot;</span><span class="p">)</span>
 <span class="n">Al_pif</span> <span class="o">=</span> <span class="n">directory_to_pif</span><span class="p">(</span><span class="s2">&quot;./example_data/Al.cF4&quot;</span><span class="p">)</span>
@@ -12364,54 +13690,53 @@ Found 16 PIFs
              <span class="k">for</span> <span class="n">x</span> <span class="ow">in</span> <span class="n">os</span><span class="o">.</span><span class="n">listdir</span><span class="p">(</span><span class="s2">&quot;./example_data/&quot;</span><span class="p">)</span> <span class="k">if</span> <span class="s2">&quot;Al&quot;</span> <span class="ow">in</span> <span class="n">x</span><span class="p">]</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[11]:</div>
+<div class="prompt input_prompt">In&nbsp;[15]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="k">def</span> <span class="nf">enthalpy_of_formation</span><span class="p">(</span><span class="n">energy</span><span class="p">,</span> <span class="n">n_Al</span><span class="p">,</span> <span class="n">n_Cu</span><span class="p">,</span> <span class="n">energy_Al</span><span class="p">,</span> <span class="n">energy_Cu</span><span class="p">):</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="k">def</span> <span class="nf">enthalpy_of_formation</span><span class="p">(</span><span class="n">energy</span><span class="p">,</span> <span class="n">n_Al</span><span class="p">,</span> <span class="n">n_Cu</span><span class="p">,</span> <span class="n">energy_Al</span><span class="p">,</span> <span class="n">energy_Cu</span><span class="p">):</span>
     <span class="k">return</span> <span class="p">(</span><span class="n">energy</span> <span class="o">-</span> <span class="n">n_Al</span> <span class="o">*</span> <span class="n">energy_Al</span> <span class="o">-</span> <span class="n">n_Cu</span> <span class="o">*</span> <span class="n">energy_Cu</span><span class="p">)</span> <span class="o">/</span> <span class="p">(</span><span class="n">n_Al</span> <span class="o">+</span> <span class="n">n_Cu</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[12]:</div>
+<div class="prompt input_prompt">In&nbsp;[16]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">import</span> <span class="nn">re</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">re</span>
 
 <span class="k">def</span> <span class="nf">get_stoich</span><span class="p">(</span><span class="n">AlCu_formula</span><span class="p">):</span>
     <span class="n">m</span> <span class="o">=</span> <span class="n">re</span><span class="o">.</span><span class="n">match</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;Al([0-9]*)Cu([0-9]*)&quot;</span><span class="p">,</span> <span class="n">AlCu_formula</span><span class="p">)</span>
-    <span class="k">if</span> <span class="n">m</span> <span class="ow">is</span> <span class="ow">not</span> <span class="bp">None</span><span class="p">:</span>
+    <span class="k">if</span> <span class="n">m</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">n_Al</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">1</span><span class="p">))</span> <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">1</span><span class="p">))</span> <span class="o">&gt;</span> <span class="mi">0</span> <span class="k">else</span> <span class="mi">1</span>
         <span class="n">n_Cu</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">2</span><span class="p">))</span> <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">2</span><span class="p">))</span> <span class="o">&gt;</span> <span class="mi">0</span> <span class="k">else</span> <span class="mi">1</span>
         <span class="k">return</span> <span class="p">(</span><span class="n">n_Al</span><span class="p">,</span> <span class="n">n_Cu</span><span class="p">)</span>
     <span class="n">m</span> <span class="o">=</span> <span class="n">re</span><span class="o">.</span><span class="n">match</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;Cu([0-9]*)Al([0-9]*)&quot;</span><span class="p">,</span> <span class="n">AlCu_formula</span><span class="p">)</span>
-    <span class="k">if</span> <span class="n">m</span> <span class="ow">is</span> <span class="ow">not</span> <span class="bp">None</span><span class="p">:</span>
+    <span class="k">if</span> <span class="n">m</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
         <span class="n">n_Cu</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">1</span><span class="p">))</span> <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">1</span><span class="p">))</span> <span class="o">&gt;</span> <span class="mi">0</span> <span class="k">else</span> <span class="mi">1</span>
         <span class="n">n_Al</span> <span class="o">=</span> <span class="nb">float</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">2</span><span class="p">))</span> <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">m</span><span class="o">.</span><span class="n">group</span><span class="p">(</span><span class="mi">2</span><span class="p">))</span> <span class="o">&gt;</span> <span class="mi">0</span> <span class="k">else</span> <span class="mi">1</span>
         <span class="k">return</span> <span class="p">(</span><span class="n">n_Al</span><span class="p">,</span> <span class="n">n_Cu</span><span class="p">)</span>
     <span class="k">return</span> <span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>ReadView is a dictionary-like read-only view into a PIF that indexes members by name and elevates keys up the PIF hierarchy as long as they are unambiguous. For more info see the docs.</p>
 <p>Here, we'll use ReadView to populate an array of <code>(Energy, formula)</code> tuples to build our phase diagram.</p>
@@ -12421,10 +13746,10 @@ Found 16 PIFs
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[13]:</div>
+<div class="prompt input_prompt">In&nbsp;[17]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="kn">from</span> <span class="nn">pypif_sdk.readview</span> <span class="kn">import</span> <span class="n">ReadView</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">pypif_sdk.readview</span> <span class="k">import</span> <span class="n">ReadView</span>
 
 <span class="n">energy_Al</span> <span class="o">=</span> <span class="n">ReadView</span><span class="p">(</span><span class="n">Al_pif</span><span class="p">)[</span><span class="s2">&quot;Total Energy&quot;</span><span class="p">]</span><span class="o">.</span><span class="n">scalars</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">value</span> <span class="o">/</span> <span class="mi">4</span>
 <span class="n">energy_Cu</span> <span class="o">=</span> <span class="n">ReadView</span><span class="p">(</span><span class="n">Cu_pif</span><span class="p">)[</span><span class="s2">&quot;Total Energy&quot;</span><span class="p">]</span><span class="o">.</span><span class="n">scalars</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">value</span>
@@ -12441,14 +13766,13 @@ Found 16 PIFs
         <span class="p">))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>Now, let's add the new points from our queries above.</p>
 
@@ -12457,10 +13781,10 @@ Found 16 PIFs
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[16]:</div>
+<div class="prompt input_prompt">In&nbsp;[18]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">new_points</span> <span class="o">=</span> <span class="p">[]</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">new_points</span> <span class="o">=</span> <span class="p">[]</span>
 <span class="k">for</span> <span class="n">hit</span> <span class="ow">in</span> <span class="n">res</span><span class="o">.</span><span class="n">hits</span><span class="p">:</span>
     <span class="n">n_Al</span><span class="p">,</span> <span class="n">n_Cu</span> <span class="o">=</span> <span class="n">get_stoich</span><span class="p">(</span><span class="n">hit</span><span class="o">.</span><span class="n">extracted</span><span class="p">[</span><span class="s2">&quot;formula&quot;</span><span class="p">])</span>
     <span class="n">new_points</span><span class="o">.</span><span class="n">append</span><span class="p">((</span>
@@ -12469,18 +13793,18 @@ Found 16 PIFs
         <span class="p">))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[17]:</div>
+<div class="prompt input_prompt">In&nbsp;[19]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="o">%</span><span class="k">matplotlib</span> inline
-<span class="kn">import</span> <span class="nn">matplotlib.pyplot</span> <span class="kn">as</span> <span class="nn">plt</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="o">%</span><span class="k">matplotlib</span> inline
+<span class="kn">import</span> <span class="nn">matplotlib.pyplot</span> <span class="k">as</span> <span class="nn">plt</span>
 
 <span class="n">plt</span><span class="o">.</span><span class="n">scatter</span><span class="p">(</span><span class="o">*</span><span class="nb">zip</span><span class="p">(</span><span class="o">*</span><span class="n">points</span><span class="p">),</span> <span class="n">color</span><span class="o">=</span><span class="s1">&#39;blue&#39;</span><span class="p">,</span> <span class="n">marker</span><span class="o">=</span><span class="s1">&#39;o&#39;</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;alloyDB&#39;</span><span class="p">)</span>
 <span class="n">plt</span><span class="o">.</span><span class="n">scatter</span><span class="p">(</span><span class="o">*</span><span class="nb">zip</span><span class="p">(</span><span class="o">*</span><span class="n">new_points</span><span class="p">),</span> <span class="n">color</span><span class="o">=</span><span class="s1">&#39;red&#39;</span><span class="p">,</span> <span class="n">marker</span><span class="o">=</span><span class="s1">&#39;x&#39;</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;citrination&#39;</span><span class="p">)</span>
@@ -12490,7 +13814,7 @@ Found 16 PIFs
 <span class="n">plt</span><span class="o">.</span><span class="n">ylabel</span><span class="p">(</span><span class="s2">&quot;$\Delta H (eV/atom)$&quot;</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12500,26 +13824,26 @@ Found 16 PIFs
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[17]:</div>
+    <div class="prompt output_prompt">Out[19]:</div>
 
 
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>Text(0,0.5,u&#39;$\\Delta H (eV/atom)$&#39;)</pre>
+<pre>Text(0,0.5,&#39;$\\Delta H (eV/atom)$&#39;)</pre>
 </div>
 
 </div>
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 
 
 <div class="output_png output_subarea ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzt3Xt0VfWZ//H3E0QhFQEBkSVNQq0CXjCY1LGzSr3AtNRe1JYWnVShOpNVrBrjr1ptVi1jy4y1/oxB7c+mU0EkrdTWqWitjqBUVLQGCQiIxSpBFBVRGMeAAnl+f+wdck5IzDlJ9rl+Xmuddc7+7r3PebJXcp58L/v7NXdHREQkSgXpDkBERHKfko2IiEROyUZERCKnZCMiIpFTshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERidxB6Q4gXYYPH+4lJSXpDkNEJKusXLnyHXcfkex5eZtsSkpKaGxsTHcYIiJZxcyae3KemtFERCRySjYiIhI5JRsREYlc3vbZiEhu2LNnD1u2bGH37t3pDiWnDBgwgNGjR9O/f/8+eT8lGxHJalu2bGHQoEGUlJRgZukOJye4O9u3b2fLli2MGTOmT95TzWgiktV2797NsGHDlGj6kJkxbNiwPq0tKtmISNZToul7fX1NlWxERCRySjYiIhEoKSnhnXfeAeDQQw/t0XssW7aMwYMHM3HiRMaOHcvnP/95Hnzwwf37Z8+ezVFHHUVpaSnjxo1j1qxZtLa29kn8fU3JRkQkg02aNIlVq1bx0ksvMXfuXC699FKWLl26f391dTVNTU2sX7+eF154gb/85S9pjLZrSjYiklcaGqCkBAoKgueGht6/5znnnENZWRnHH3889fX1XR7n7lx11VWccMIJnHjiiSxatAiACy+8kD/+8Y/7j6uoqOD+++8/4PzS0lKuu+46brvttgP2ffTRR+zevZuhQ4f2/geKgJKNiOSNhgaorITmZnAPnisre59w7rzzTlauXEljYyNz585l+/btnR5333330dTUxOrVq1myZAlXXXUVW7du5eKLL2b+/PkA7Ny5k6effpovf/nLnb7HySefzIYNG/Zv19bWUlpayqhRozj22GMpLS3t3Q8TESUbEckbNTXQ0hJf1tISlPfG3LlzOemkkzj11FN57bXX2LhxY6fHPfnkk5x//vn069ePkSNHctppp/Hcc89x2mmnsXHjRrZt28Zvf/tbvvGNb3DQQZ3fBunucdttzWhvv/02H3zwAffcc0/vfpiIKNmISN7YvDm58kQsW7aMJUuWsGLFClavXs3EiRN7dH/KhRdeyMKFC5k3bx4XXXRRl8etWrWK8ePHH1Dev39/pk6dyhNPPJH0Z6eCko2I5I2iouTKE7Fz506GDh1KYWEhGzZs4Jlnnuny2EmTJrFo0SL27dvHtm3beOKJJzjllFMAmDlzJrfccgsAxx13XKfnr1mzhp/85Cd873vfO2Cfu/PUU09x9NFH9/yHiZCmqxGRvDFnTtBHE9uUVlgYlPfU1KlTueOOOxg/fjxjx47l1FNP7fLYc889lxUrVnDSSSdhZtx4440ceeSRAIwcOZLx48dzzjnnxJ2zfPlyJk6cSEtLC0cccQRz585l8uTJ+/fX1taycOFC9uzZw4QJE7jkkkt6/sNEyd0z4gFMBV4CXgau6WT/IcCicP+zQEnMvmvD8peALyb2eWVeXOy+cKGLSBZbv359UscvXOheXOxu5hn1HfDBBx/4pz71Kd+xY0e6Q9kv9tq2XTcoc+/Bd3xGNKOZWT/gduBLwHHA+WbWsR55MfCeu38aqAV+Fp57HHAecDxBwvpF+H7d6quRKCKSPSoqYNMmaG0Nnisq0h0RLFmyhPHjx3PZZZcxePDgdIdzgNhRfD2VEckGOAV42d1fcfePgHuAszscczZwV/j698BkCybvORu4x90/dPdXCWo4pyT6wX0xEkVEpDemTJlCc3MzV1xxRbpD6VRno/iSlSnJ5ijgtZjtLWFZp8e4+15gJzAswXMBMLNKM2s0s0bYtr+8NyNRRERyXV98R2ZKskkJd69393J3L4cR+8t7MxJFRCTX9cV3ZKYkm9eBT8Zsjw7LOj3GzA4CBgPbEzy3S70diSIikuvmzAm+K3sjU5LNc8AxZjbGzA4m6PBf3OGYxcCM8PU04DF397D8PDM7xMzGAMcAf03kQ4uLob4+MzoIRUQyVUVF8F1ZXNzz98iIZBP2wVwKPAK8CPzO3deZ2fVm9rXwsF8Dw8zsZeBK4Jrw3HXA74D1wMPA99x9X3efWVaWOSNRRCS33HHHHSxYsACA+fPn88Ybb3R57HXXXceSJUt69DlNTU089NBD+7cXL17MDTfc0KP36k7bKD5YubIn55t3mGcnX5SXl3tjY2O6wxCRXnrxxRc7nb6lS+4Quwplx+0+dvrpp3PTTTdRXl5+wL59+/bRr19Cd2p0av78+TQ2NnY6C3Rf6OzamtnKoN87OZpBQETyx+zZsGMH1NYGCcYdqqthyJBgXw8tWLCAm266CTNjwoQJHH300Rx66KGUlJTQ2NhIRUUFAwcOZMWKFYwfP57p06fz6KOPcvXVV/Pwww/zla98hWnTplFSUsKMGTN44IEH2LNnD/feey/jxo3jr3/9K1VVVezevZuBAwcyb948xowZw3XXXceuXbt48sknufbaa9m1a9f+5LNp0yYuuugi3nnnHUaMGMG8efMoKipi5syZHHbYYTQ2NvLmm29y4403Mm3atD67xF3JiGY0EZHIuQeJpq4uSDBtiaauLijvYSvPunXr+OlPf8pjjz3G6tWrqaur279v2rRplJeX09DQQFNTEwMHDgRg2LBhPP/885x33nkHvN/w4cN5/vnnmTVrFjfddBMA48aNY/ny5axatYrrr7+eH/7whxx88MFcf/31TJ8+naamJqZPnx73PpdddhkzZsxgzZo1VFRUcPnll+/ft3XrVp588kkefPBBrrnmmh793MlSzUZE8oNZUKOBIMG0JYWqqvaaTg889thjfPOb32T48OEAHH744d2e0zExxPr6178OQFlZGffddx8QTPY5Y8YMNm7ciJmxZ8+ebj9jxYoV+8+/4IILuPrqq/fvO+eccygoKOC4447jrbfe6va9+oJqNiKSP2ITTpteJJqe+sQnPtHlvkMOOQSAfv36sXfvXgB+9KMfccYZZ7B27VoeeOCBHi1h0NlnwIHr40RFyUZE8kdb01mstia1HjrzzDO5995796/O+e6778btHzRoEO+//36P3x+Cms1RRwUTo7St6Nnde//jP/7j/oXUGhoamDRpUq9i6C0lGxHJD7F9NFVVwUycVVXxfTg9cPzxx1NTU8Npp53GSSedxJVXXhm3f+bMmXz3u9+ltLSUXbt29egzrr76aq699lomTpy4v7YDcMYZZ7B+/XpKS0tZtGhR3Dm33nor8+bNY8KECdx9991xfUnpoKHPIpLVkhr6HNFotFyloc8iIj0xe3b8fTVtfTgp7rPJR2pGE5H80jGxKNGkhJKNiGS9fO0OiFJfX1MlGxHJagMGDGD79u1KOH3I3dm+fTsDBgzos/dUn42IZLXRo0ezZcsWtm3b1v3BkrABAwYwevToPns/JRvJHimeQFGyQ//+/RkzZky6w5BuqBlNssPs2fH3QrQNWdVwVZGsoGQjmS+iCRRFJHXUjCaZL6IJFEUkdTSDgGQPdyiIqYy3tirRiKRYT2cQUDOaZIcIJlDMNA0NUFIS5NOSkmBbJFco2Ujmi2gCxUzS0ACVldDcHPw4zc3BthKO5Ar12UjmMwsmSozto2nrwxkyJCea0mpqoKUlvqylJSivqEhPTCJ9SX02kj1y+D6bgoLOK2hmQUVOJFOoz0ZyXw5PoFhUlFy5SLZRshHJAHPmQGFhfFlhYVAukguUbEQyQEUF1NdDcXFQYSsuDrbVXyO5QgMERDJERYWSi+Qu1WxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCKnZCMiIpFLe7Ixs8PN7FEz2xg+D+3iuBnhMRvNbEZM+TIze8nMmsLHEamLXkREEpH2ZANcAyx192OApeF2HDM7HPgx8A/AKcCPOySlCncvDR9vpyJoERFJXCYkm7OBu8LXdwHndHLMF4FH3f1dd38PeBSYmqL4RESklzIh2Yx0963h6zeBkZ0ccxTwWsz2lrCszbywCe1HZjk0O6OISI5IyXQ1ZrYEOLKTXTWxG+7uZpbsmgcV7v66mQ0C/gBcACzoIo5KoBKgSNPpioikTEqSjbtP6Wqfmb1lZqPcfauZjQI663N5HTg9Zns0sCx879fD5/fN7DcEfTqdJht3rwfqIVjPJvmfREREeiITmtEWA22jy2YA93dyzCPAF8xsaDgw4AvAI2Z2kJkNBzCz/sBXgLUpiFlERJKQCcnmBuCfzGwjMCXcxszKzew/Adz9XeAnwHPh4/qw7BCCpLMGaCKoAf0q9T+CiIh8HC0LLSIiCdOy0CIikrGUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkREIqdkIyIikVOyEZG0aWiAkhIoKAieGxrSHZFEJSVzo4mIdNTQAJWV0NISbDc3B9sAFRXpi0uioZqNiKRFTU17omnT0hKUS+5RshGRtNi8OblyyW5JJxsz+4SZ9YsiGBHJH10tKaWlpnJTt8nGzArM7J/N7E9m9jawAdhqZuvN7Odm9unowxSRXDNnDhQWxpcVFgblknsSqdk8DhwNXAsc6e6fdPcjgM8BzwA/M7NvRxijiOSgigqor4fiYjALnuvrNTggV3W7xICZ9Xf3Pb09JtNoiQERkeRFtsRAbBIJV8P82GNEREQ6Svg+m3DVzC+b2V7gDWANsMbdb40qOBERyQ3J3NQ5CRjt7vvM7CjgJGBCNGGJiEguSSbZPAsMA95299eB14GHIolKRERySjL32fwS+IuZfd/MJpnZ4KiCEhGR3JJMslkILCCoDV0CPG1mf48kKhERySnJNKNtcff/iC0ws0P6OB4REclBydRsmsysKrbA3T/s43hERCQHJVOzGQlMMbMfAM8Dq4Emd783kshERCRnJJxs3P1bsL/p7HjgROAfACUbERH5WMnc1Hk4UA0cAawHFrj7XVEFJlnCPZjYqqttERGS67O5B3gfeAAoBJ40s1MiiUqyw+zZUF0dJBgInqurg3IRkRjJJJsR7n6juz8Yjkr7KjA3orgk07nDjh1QV9eecKqrg+0dO9oTkIgIyQ0QeNfMTnT3FwDc/RUzK+zuJMlRZlBbG7yuqwseAFVVQbma0kQkRrdLDOw/0Gwc8HtgOfACcBxwlLufG1140dESA33EHQpiKsitrUo0IjkssiUGYuwGTiZYTO0IgqHP5yf7gZJD2prOYsX24YiIhJJJNve5+0fu/jt3n+3uvwJKexuAmR1uZo+a2cbweWgXxz1sZjvM7MEO5WPM7Fkze9nMFpnZwb2NSRIQ20dTVRXUaKqq4vtwRERC3SYbM/uWmd0ADDKz8WYWe059H8RwDbDU3Y8Blobbnfk5cEEn5T8Dat3908B7wMV9EJN0xwyGDInvo6mtDbaHDFFTmojESWRZ6KOAycDNwHPAWGAHwQJqI9z9H3oVgNlLwOnuvtXMRgHL3H1sF8eeDnzf3b8SbhuwDTjS3fea2WeB2e7+xe4+V302fUT32YjklZ722XQ7Gi1cu2aBmf3d3Z8KP2wYUAJsSPYDOzHS3beGr98kmBYnUcOAHe6+N9zeAhzVBzFJojomFiUaEelEMkOfN5jZLIKBAuuAF9x9VyInmtkS4MhOdtXEbri7m1lkjf1mVglUAhQVFUX1MSIi0kEyyea/gCXALOBvwGfN7BV3H9fdie4+pat9ZvaWmY2KaUZ7O4mYtgNDzOygsHYzmmAF0a7iqCfsZyovL1cPtohIiiQzGm2Qu18PvOXupxEMe/5dH8SwGJgRvp4B3J/oiR50OD0OTOvJ+SIikhrJ3mcD8KGZDXT3PwBf6IMYbgD+ycw2AlPCbcys3Mz+s+0gM1tOMMP0ZDPbYmZtgwB+AFxpZi8T9OH8ug9iEhGRPpRMM9pN4czPi4A7zexpYEhvA3D37QSj3TqWNwL/ErM9qYvzXwE0IaiISAZL5D6bz5qZufsf3P1dd78Z+DPwSeDrkUcoIiJZL5GazYXA7Wb2N+Bh4GF3XxBtWCIikksSuc9mFuyfiPNLwHwzG0zQMf8w8JS774s0ShERyWqJNKONB3D3De5e6+5TgTOBJ4FvAs9GG6KIiGS7RJrR/mRmfwGuc/fXAMKbOR8KHyIiIh8rkaHP44DngSfMrM7MRkQck4iI5Jhuk024rMCtwHjgNeCvZvYTMzss8uhERHqooQFKSoK1/UpKgm1Jn4Rv6nT33e5+E3ACsAtYaWbfjywyEZEeamiAykpobg4mIm9uDraVcNIn4WRjZiVmNpXgRssi4H3g36MKTESkp2pqoKUlvqylJSiX9Oh2gICZrSGYtn8zwZICLxIscnYbwYScIiIZZfPm5MoleomMRjsHeNW7W2VNRCRDFBUFTWedlUt6JDJA4JVwnZljzOzXZnZbKgITEempOXOgsDC+rLAwKJf0SGbW57uB3wOfBzCzE8xM09aISMapqID6eiguDhaPLS4Otisq0h1Z/kpm1ucCd/+zmf07gLuvNbMTIopLRKRXKiqUXDJJMjWbN8xsDOAAZmbAwEiiEhHJNh27tdXNHSeZZHMF8CvgSDP7DnAPsDaSqEREssns2VBd3Z5g3IPt2bPTGVVGSeamzk3AVOBy4FPAX4ALoglLRCRLuMOOHVBX155wqquD7R07VMMJJXKfjbUNe3b3vQSDBH7f1TEiInnFDGprg9d1dcEDoKoqKDdLX2wZJJGazeNmdpmZxY1QN7ODzexMM7sLmBFNeCIiWSA24bRRoomTSLKZCuwDfmtmb5jZejN7FdgInA/c4u7zI4xRRCSztTWdxYrtw5GEVurcDfwC+IWZ9QeGA7vcfUfUwYmIZLzYPpq2prO2bVANJ5RIn81Y4G8e2ANsjT6sFHLXL4KI9JwZDBkS30fT1qQ2ZIi+X0LWXb++mb0AFBNMurkGeKHt2d3fjjzCiJSXl3vjc88F/4EMGaIhiiLSOx3/cc3Rf2TNbKW7lyd7XiJzo50IjABmAV8lGPb8Q2CNmb2Z7AdmFA1PFJG+0jGx5GCi6Y1uazZxB5u96u5jYraHuvt7kUQWsXIzbwQNTxQRSUJkNZsO4jJTtiaaOEo0IiKR6zbZmNntZnaxmU0Ecu9bWcMTRUQil8isz6uBUuBCYJCZrQfWAeuB9e6+KML4olNWBp/7nIYnioikQCL32dTHbpvZaGACUEaQgLIz2YCGJ4qIpEgy69kQNqWdD5xHcL/NuCiCSpm28fBKNCIikUrkps5jCRLMPwP/C/wOOM3dXw2nrcluSjQiIpFLpGazAXgOmObuL3TYp551ERHpViJDn78OvAr8t5ndbWZfDedI6xNmdriZPWpmG8PnoV0c97CZ7TCzBzuUzzezV82sKXyU9lVsIiLSNxKZQeCP7n4e8Gngz0AlsMXM5gGH9UEM1wBL3f0YYGm43Zmf0/VibVe5e2n4aOqDmEREpA8ls1LnB+7+G3f/KsHAgBUEc6T11tnAXeHru4Bzuvj8pcD7ffB5IiKSYsnOIAAEMwe4e727n9kHMYx097aZpN8ERvbgPeaY2RozqzWzQ7o6yMwqzazRzBq3bdvWo2BFRCR5PUo2yTKzJWa2tpPH2bHHhUtLJzvo4FqCmtZngMOBH3R1YJggy929fMSIEcn+GJJuHWd60MwPKdPQACUlUFAQPDc0pDsiyTZJ3WfTU+4+pat9ZvaWmY1y961mNgpIatmCmFrRh2E/0vd7Eapkqtmzg9m52+6LaluwSstDRK6hASoroaUl2G5uDrYBKirSF5dkl5TUbLqxGJgRvp4B3J/MyWGCwsyMoL9nbZ9GJ+nnHiSaurr2uez6enkI1Zq6VFPTnmjatLQE5SKJSmqJgUgCMBtGcKNoEdAMfMvd3zWzcuC77v4v4XHLCZrLDgW2Axe7+yNm9hjBejsGNIXn/G93n1teXu6NjY2R/EwSgdgE06avlodQreljFRR0nnvNoLU19fFIeqVqiYE+5+7b3X2yux/j7lPc/d2wvLEt0YTbk9x9hLsPdPfR7v5IWH6mu5/o7ie4+7cTSTSShcy45MPauKJLPuyDRJOKWlOWKypKrlykM2lPNiKJuGSWc+wd1XFlx95RzSWzepkMwvnxNnyxKkgwBQVQVxds5+m8eR0HA5x1FhQWxh9TWAhz5qQjOslWSjaS+dwZ+8tqrqCOW6jCaOUWqriCOsb+svfrETX8xih7Ir7WVPZELQ2/yc9EU1kZDAJwD57vugtmzIDi4iD3FhdDfb0GB0hyUjIaTaRXzHjPh3ALVVRTC1j4DDu898tD1PzQmbMrvtY0Z1c1NT+spaIivxJOV4MBHnoINm1KS0g95x7/u9FxW1Iq7QME0kUDBLLLQQfBvn1O/GKxTr9+xt69vXhjd+oKqqkKa03V1FJLUIuqo4qq1vxqSsuZwQAa9BGZrB0gIJKI4L6Ojl/6tv9+jx4zwwcfWGu6hSp8cP4tqpcTgwE06CMzuXtePsrKylyyy6xZ7v36uUPwPGtW37zvwoXuhQNbPfgWCh6FA1t94cK+ef9ssnChe2Ghx1+LQs++a9Ha6l5VFf+DVFUF5dIrQKP34DtXzWgiBB3jNTWweXPwX/ycOfnbAZ4z18I9aBds09qadzXVKPS0GU3JRkRyjzsbvlTNuEfabwLe8MUqxv05v/rgoqA+GxERiEs0sUPlxz1Sx4Yv9X6ovPSMhj6LSG4x4+FnhvBwJ0PleWYI41SzSQs1o4lIzgmGcB84VN7MsmsIdwZSM5qISCgYqn3gUPmsGsKdY5RsJHtoGQBJ0Jw5ms8t0yjZSHaYPbv9Bj1ov1FPd4NLJyoqgvnbNJ9b5lCykcwXc0f4nYOrKTDnzsG6I1w+XkVFMJ9ba2vwrESTXhqNJpnPjIbyWnb0c773fh0XUQfvw+39LmdIeS0VGl0kndFEnBlFNRvJCtsu/Tf27Isv27MvKBc5gJpdM46SjWQ+d2zne1zB3LjiK5iL7XxPzWgSTxNxZiQ1o0lWGDQIeL+LcpFY4eqrQJBg6sIpa6ryd/XVTKCajWQ+M8qnDOX2fpfHFd/e73LKpwzVl4ccKDbhtFGiSSslG8kKE/7wYyZPji+bPDkoFzlAW9NZrGrNi5ZOSjaS+cIvjnH/PTdoCmlthaqqYFtfINJRbB9NzO9LXB+OpJz6bCTzmQXL+ca2ubc1kQzJv9U0pRttvy+XXRb/+9Laqt+XNFKykewwe3b8fRJtXyD64pDOLFsGO3e2/864w/LlMHhwuiPLW2pGk+zRMbEo0UhnWluDRNPUxLoBZRRYK+sGlEFTU1CuaZ/TQslGRHJLQQENV65ktZVy/J4mWunH8XuaWG2lNFy5Mn6paEkZrWcjIjmnpASam1tx+u0vM/ZRXFzApk1pCysnaD0bEZHQ5uZWnqcsrux5ytjcrCa0dFGyEZHc0trKC/3LmEgTqyjF2McqSplIEy/0L1OfTZoo2eRpM6JIziooYPjRg1ltpZzMSqCAkwn6cIYfPVh9NmmS31ddM8GK5KSRLy5j7V0rKS4uCBdPK2DtXSsZ+eKydIeWt9KebMzscDN71Mw2hs9DOzmm1MxWmNk6M1tjZtNj9o0xs2fN7GUzW2RmByf84ZoJViRnVVxQEL942gVp/7rLa5lw9a8Blrr7McDScLujFuBCdz8emArcYmZDwn0/A2rd/dPAe8DFCX3qypXt01no5kARkUilfeizmb0EnO7uW81sFLDM3cd2c85qYBrwMrANONLd95rZZ4HZ7v7F7j633MwbIfi3R4lGRCQh2Tz0eaS7bw1fvwmM/LiDzewU4GDg78AwYIe77w13bwGOSurTNTGfiEjkUjI3mpktAY7sZFdN7Ia7u5l1+c0f1nzuBma4e6slWSMxs0qgEqCoqAjOPbd9YSU1pYmIRCYlycbdp3S1z8zeMrNRMc1ob3dx3GHAn4Aad38mLN4ODDGzg8LazWjg9Y+Jox6oh2AGAc0cLCKSGpkw6/NiYAZwQ/h8f8cDwhFm/wUscPfft5WHNaHHCfpv7unq/C5p5mARkZTIhD6bG4B/MrONwJRwGzMrN7P/DI/5FvB5YKaZNYWP0nDfD4Arzexlgj6cXyf16Uo0IiKRS/totHTRRJwiGSh2zaLOtiXtsnk0mohIMJNH7OhQzfCRU5RsRCT93IOZPOrq2hOOZvjIKZkwQCC9VE0XST+zYMnm0tIgwbTdklBaGpTrbzTr5XfNRtV0kczgvn8p5zhtSzmrZpP18jvZqJoukhnM4OabebeoNK743aJSuPlm1WxyQP4mG03EKZI53Nlw1pUcvjm+ZnP45iY2nHWl/hnMAfmbbNoo0UiGaGiAkpJgba+SkmA7b5jx8IrBrCK+ZrOKUh5eoT6bXKBko4k4JQM0NEBlJTQ3B7+Ozc3Bdt4kHHfsf3YykSZuoQqjlVuoYiJN2P+ozyYX5O9otLIy+NznNBGnZISaGmhpiS9raQnKKyrSE1NKmeGDh3DLziqqqQUsfAYGa+7CXJC/yQbQRJySKTZvTq48F424fTaV/+qwq+1v0agZWEv97frbzAX5nWw0EadkiKKioOmss/J8EdTgjJqaIMkWFcGcOZYfNbs8oD4bJRrJAHPmQGFhfFlhYVCeTyoqYNOmYAHdTZvypAkxTyjZiGSAigqor4fi4uD/n+LiYFtftpIr8rsZTSSDVFQouUjuUs1GREQip2QjIiKRU7IREZHIKdmIiEjklGxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCKnZCMiIpFTshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRM7cPd0xpIWZvQ+8lO44MsRw4J10B5EhdC3a6Vq007VoN9bdByV7Uj6v1PmSu5enO4hMYGaNuhYBXYt2uhbtdC3amVljT85TM5qIiEROyUZERCKXz8mmPt0BZBBdi3a6Fu10LdrpWrSRch+UAAAF6klEQVTr0bXI2wECIiKSOvlcsxERkRTJ+WRjZlPN7CUze9nMrulk/yFmtijc/6yZlaQ+yuglcB2uNLP1ZrbGzJaaWXE64kyF7q5FzHHfMDM3s5wdhZTItTCzb4W/G+vM7DepjjFVEvgbKTKzx81sVfh3clY64kwFM7vTzN42s7Vd7DczmxteqzVmdnK3b+ruOfsA+gF/Bz4FHAysBo7rcMwlwB3h6/OARemOO03X4QygMHw9KxevQ6LXIjxuEPAE8AxQnu640/h7cQywChgabh+R7rjTeC3qgVnh6+OATemOO8Lr8XngZGBtF/vPAv4MGHAq8Gx375nrNZtTgJfd/RV3/wi4Bzi7wzFnA3eFr38PTDYzS2GMqdDtdXD3x929Jdx8Bhid4hhTJZHfCYCfAD8DdqcyuBRL5Fr8K3C7u78H4O5vpzjGVEnkWjhwWPh6MPBGCuNLKXd/Anj3Yw45G1jggWeAIWY26uPeM9eTzVHAazHbW8KyTo9x973ATmBYSqJLnUSuQ6yLCf5ryUXdXouwSeCT7v6nVAaWBon8XhwLHGtmT5nZM2Y2NWXRpVYi12I28G0z2wI8BFyWmtAyUrLfKXk9g4B0wsy+DZQDp6U7lnQwswLgZmBmmkPJFAcRNKWdTlDbfcLMTnT3HWmNKj3OB+a7+/81s88Cd5vZCe7emu7AskGu12xeBz4Zsz06LOv0GDM7iKB6vD0l0aVOItcBM5sC1ABfc/cPUxRbqnV3LQYBJwDLzGwTQXv04hwdJJDI78UWYLG773H3V4G/ESSfXJPItbgY+B2Au68ABhDMmZaPEvpOiZXryeY54BgzG2NmBxMMAFjc4ZjFwIzw9TTgMQ97wHJIt9fBzCYCvyRINLnaLg/dXAt33+nuw929xN1LCPqvvubuPZoPKsMl8vfxR4JaDWY2nKBZ7ZVUBpkiiVyLzcBkADMbT5BstqU0ysyxGLgwHJV2KrDT3bd+3Ak53Yzm7nvN7FLgEYLRJne6+zozux5odPfFwK8JqsMvE3SInZe+iKOR4HX4OXAocG84PmKzu38tbUFHJMFrkRcSvBaPAF8ws/XAPuAqd8+1mn+i1+L/AL8ys2qCwQIzc/AfUwDM7LcE/2QMD/uofgz0B3D3Owj6rM4CXgZagO90+545eq1ERCSD5HozmoiIZAAlGxERiZySjYiIRE7JRkREIqdkIyIikVOyEUmQmR1pZveY2d/NbKWZPWRmxyZx/jgzawpnDT66l7GUxs46bGZf+7gZrEXSTUOfRRIQTs76NHBXeJ8BZnYScJi7L0/wPa4BDnL3n3by3pbMtCdmNpNgNupLEz1HJJ1UsxFJzBnAnrZEA+Duq919uZmdbmYPtpWb2W1hMiCm7CzgCmBWuCZKSbh2ygJgLfBJM/t/ZtYYrhvzbzHnfsbMnjaz1Wb2VzMbDFwPTA9rStPNbKaZ3RYeX2Jmj1n72kRFYfn8cA2Sp83sFTObFt3lEomnZCOSmBOAlT092d0fAu4Aat39jLD4GOAX7n68uzcDNe5eDkwATjOzCeHUKYuAKnc/CZgCfABcR7DmUKm7L+rwcbcS1MAmAA3A3Jh9o4DPAV8BbujpzyOSrJyerkYkwzWHa4G0+ZaZVRL8XY4iWKDLga3u/hyAu/8PQDdLLn0W+Hr4+m7gxph9fwyb69ab2cg++SlEEqCajUhi1gFlXezbS/zf0oAE3/ODthdmNgb4PjA5rJH8KYn3SUbsbN65tkigZDAlG5HEPAYcEtY8AAibuSYBzcBxZnaImQ0hnBk4SYcRJJ+dYY3jS2H5S8AoM/tM+JmDwqUw3idYDqEzT9M+oWwFkNAABpEoKdmIJCCc3fdcYEo49Hkd8B/Am+7+GsE6J2vD51U9eP/V4XkbgN8AT4XlHwHTgVvNbDXwKEGN53GCBNdkZtM7vN1lwHfMbA1wAVCVbDwifU1Dn0VEJHKq2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkREIqdkIyIikVOyERGRyP1/C3ufuBG+GjwAAAAASUVORK5CYII=
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3X2YVWW9//H3Z/ABJxEUFL0kZshU8HGQOR471zE1OWX2oJWlnkmxPIcrLBvxl6ZxZRyLc8z8hVD2Mzr5yJRkdcrM9IhmamI5yIBKGGaAGCqhcDwiBsz398daA3vGGWfvmVl779n787quufZe91pr7+9eDPs798O6b0UEZmZmWaopdQBmZlb5nGzMzCxzTjZmZpY5JxszM8uck42ZmWXOycbMzDLnZGNmZplzsjEzs8w52ZiZWeZ2KXUApTJq1Kior68vdRhmZoPK4sWL/xoR+xZ6XtUmm/r6elpbW0sdhpnZoCJpdV/OczOamZllzsnGzMwy52RjZmaZq9o+GzOrDFu3bmXt2rVs2bKl1KFUlKFDhzJmzBh23XXXAXk9JxszG9TWrl3LsGHDqK+vR1Kpw6kIEcGGDRtYu3Yt48aNG5DXdDOamQ1qW7ZsYeTIkU40A0gSI0eOHNDaopONmQ16TjQDb6CvqZONmZllzsnGzCwD9fX1/PWvfwVgzz337NNrPPDAAwwfPpyJEydy6KGH8u53v5s777xzx/6ZM2dy4IEH0tDQwPjx45k2bRrt7e0DEv9Ac7IxMytjxx9/PEuWLOHpp59m7ty5fO5zn+O+++7bsX/69Om0tbWxfPlynnjiCX7zm9+UMNqeOdmYWVVpaYH6eqipSR5bWvr/mqeffjqTJk3i8MMPZ968eT0eFxFccsklHHHEERx55JEsWLAAgHPPPZef/exnO45ramri5z//+ZvOb2ho4IorruDb3/72m/b97W9/Y8uWLey99979/0AZcLIxs6rR0gJTp8Lq1RCRPE6d2v+Ec8MNN7B48WJaW1uZO3cuGzZs6Pa4n/70p7S1tbF06VIWLlzIJZdcwrp16zj//PO56aabANi0aROPPPIIH/jAB7p9jWOOOYYVK1bs2J49ezYNDQ0ccMABHHLIITQ0NPTvw2TEycbMqsaMGbB5c+eyzZuT8v6YO3cuRx99NMcddxzPPfccK1eu7Pa4hx9+mLPPPpshQ4YwevRoTjjhBB577DFOOOEEVq5cyfr16/nhD3/Ixz72MXbZpfvbICOi03ZHM9pLL73Ea6+9xm233da/D5MRJxszqxpr1hRWno8HHniAhQsXsmjRIpYuXcrEiRP7dH/Kueeey/z587nxxhv59Kc/3eNxS5YsYcKECW8q33XXXTnllFN48MEHC37vYnCyMbOqMXZsYeX52LRpE3vvvTe1tbWsWLGCRx99tMdjjz/+eBYsWMD27dtZv349Dz74IMceeywA5513Htdeey0Ahx12WLfnL1u2jK9+9at89rOffdO+iOC3v/0tBx10UN8/TIY8XY2ZVY1Zs5I+mtymtNrapLyvTjnlFK6//nomTJjAoYceynHHHdfjsR/5yEdYtGgRRx99NJK4+uqr2X///QEYPXo0EyZM4PTTT+90zkMPPcTEiRPZvHkz++23H3PnzuXkk0/esX/27NnMnz+frVu3ctRRR3HBBRf0/cNkKSLK4gc4BXgaeAa4rJv9uwML0v2/A+pz9l2elj8NvC+/95sUdXUR8+eHmQ1iy5cvL+j4+fMj6uoipCir74DXXnst3vGOd8TGjRtLHcoOude247rBpIg+fMeXRTOapCHAdcD7gcOAsyV1rUeeD7wSEe8EZgNfT889DDgLOJwkYX0nfb1eDdRIFDMbPJqaYNUqaG9PHpuaSh0RLFy4kAkTJnDhhRcyfPjwUofzJrmj+PqqLJINcCzwTEQ8GxF/A24DTutyzGnAzenzHwMnK5m85zTgtoh4IyL+TFLDOTbfNx6IkShmZv0xefJkVq9ezUUXXVTqULrV3Si+QpVLsjkQeC5ne21a1u0xEbEN2ASMzPNcACRNldQqqRXW7yjvz0gUM7NKNxDfkeWSbIoiIuZFRGNENMK+O8r7MxLFzKzSDcR3ZLkkm+eBt+dsj0nLuj1G0i7AcGBDnuf2qL8jUczMKt2sWcl3ZX+US7J5DDhY0jhJu5F0+N/R5Zg7gCnp8zOA+yMi0vKzJO0uaRxwMPD7fN60rg7mzSuPDkIzs3LV1JR8V9bV9f01yiLZpH0wnwPuAf4A/CginpJ0paQPp4d9Hxgp6RngYuCy9NyngB8By4G7gc9GxPbe3nPSpPIZiWJmleX666/nlltuAeCmm27iL3/5S4/HXnHFFSxcuLBP79PW1sZdd921Y/uOO+7gqquu6tNr9aZjFB8sXtyX8xVd5tmpFo2NjdHa2lrqMMysn/7whz90O31LjyIgdxXKrtsD7MQTT+Saa66hsbHxTfu2b9/OkCF53anRrZtuuonW1tZuZ4EeCN1dW0mLk37vwngGATOrHjNnwsaNMHt2kmAiYPp0GDEi2ddHt9xyC9dccw2SOOqoozjooIPYc889qa+vp7W1laamJvbYYw8WLVrEhAkTOPPMM7n33nu59NJLufvuu/ngBz/IGWecQX19PVOmTOEXv/gFW7du5fbbb2f8+PH8/ve/p7m5mS1btrDHHntw4403Mm7cOK644gpef/11Hn74YS6//HJef/31Hcln1apVfPrTn+avf/0r++67LzfeeCNjx47lvPPOY6+99qK1tZUXXniBq6++mjPOOGPALnFPyqIZzcwscxFJopkzJ0kwHYlmzpykvI+tPE899RRf+9rXuP/++1m6dClz5szZse+MM86gsbGRlpYW2tra2GOPPQAYOXIkjz/+OGedddabXm/UqFE8/vjjTJs2jWuuuQaA8ePH89BDD7FkyRKuvPJKvvSlL7Hbbrtx5ZVXcuaZZ9LW1saZZ57Z6XUuvPBCpkyZwrJly2hqauLzn//8jn3r1q3j4Ycf5s477+Syyy7r0+culGs2ZlYdpKRGA0mC6UgKzc07azp9cP/99/Pxj3+cUaNGAbDPPvv0ek7XxJDrox/9KACTJk3ipz/9KZBM9jllyhRWrlyJJLZu3drreyxatGjH+eeccw6XXnrpjn2nn346NTU1HHbYYbz44ou9vtZAcM3GzKpHbsLp0I9E01dve9vbety3++67AzBkyBC2bdsGwJe//GVOOukknnzySX7xi1/0aQmD7t4D3rw+TlacbMysenQ0neXqaFLro/e85z3cfvvtO1bnfPnllzvtHzZsGK+++mqfXx+Sms2BByYTo3Ss6Nnba//DP/zDjoXUWlpaOP744/sVQ3852ZhZdcjto2luTmbibG7u3IfTB4cffjgzZszghBNO4Oijj+biiy/utP+8887jM5/5DA0NDbz++ut9eo9LL72Uyy+/nIkTJ+6o7QCcdNJJLF++nIaGBhYsWNDpnG9961vceOONHHXUUdx6662d+pJKwUOfzWxQK2joc0aj0SqVhz6bmfXFzJmd76vp6MMpcp9NNXIzmplVl66JxYmmKJxszGzQq9bugCwN9DV1sjGzQW3o0KFs2LDBCWcARQQbNmxg6NChA/aa7rMxs0FtzJgxrF27lvXr1/d+sOVt6NChjBkzZsBez8nGBo8iT6Bog8Ouu+7KuHHjSh2G9cLNaDY4zJzZ+V6IjiGrHq5qNig42Vj5y2gCRTMrHjejWfnLaAJFMysezyBgg0cE1ORUxtvbnWjMiqyvMwi4Gc0GhwwmUCw3LS1QX5/k0/r6ZNusUjjZWPnLaALFctLSAlOnwurVycdZvTrZdsKxSuE+Gyt/UjJRYm4fTUcfzogRFdGUNmMGbN7cuWzz5qS8qak0MZkNJPfZ2OBRwffZ1NR0X0GTkoqcWblwn41VvgqeQHHs2MLKzQYbJxuzMjBrFtTWdi6rrU3KzSqBk41ZGWhqgnnzoK4uqbDV1SXb7q+xSuEBAmZloqnJycUql2s2ZmaWOScbMzPLnJONmZllzsnGzMwy52RjZmaZc7IxM7PMlTzZSNpH0r2SVqaPe/dw3JT0mJWSpuSUPyDpaUlt6c9+xYvezMzyUfJkA1wG3BcRBwP3pdudSNoH+Arw98CxwFe6JKWmiGhIf14qRtBmZpa/ckg2pwE3p89vBk7v5pj3AfdGxMsR8QpwL3BKkeIzM7N+KodkMzoi1qXPXwBGd3PMgcBzOdtr07ION6ZNaF+WKmh2RjOzClGU6WokLQT272bXjNyNiAhJha550BQRz0saBvwEOAe4pYc4pgJTAcZ6Ol0zs6IpSrKJiMk97ZP0oqQDImKdpAOA7vpcngdOzNkeAzyQvvbz6eOrkn5A0qfTbbKJiHnAPEjWsyn8k5iZWV+UQzPaHUDH6LIpwM+7OeYe4L2S9k4HBrwXuEfSLpJGAUjaFfgg8GQRYjYzswKUQ7K5CvgnSSuByek2khol/SdARLwMfBV4LP25Mi3bnSTpLAPaSGpA3yv+RzAzs7fiZaHNzCxvXhbazMzKlpONmZllzsnGzMwy52RjZmaZc7IxM7PMOdmYmVnmnGzMzCxzTjZmVjItLVBfDzU1yWNLS6kjsqwUZW40M7OuWlpg6lTYvDnZXr062QZoaipdXJYN12zMrCRmzNiZaDps3pyUW+VxsjGzklizprByG9wKTjaS3iZpSBbBmFn16GlJKS81VZl6TTaSaiT9s6RfSnoJWAGsk7Rc0jckvTP7MM2s0syaBbW1nctqa5Nyqzz51Gx+DRwEXA7sHxFvj4j9gH8EHgW+LumTGcZoZhWoqQnmzYO6OpCSx3nzPDigUvW6xICkXSNia3+PKTdeYsDMrHCZLTGQm0TS1TDf8hgzM7Ou8r7PJl018wOStgF/AZYByyLiW1kFZ2ZmlaGQmzqPB8ZExHZJBwJHA0dlE5aZmVWSQpLN74CRwEsR8TzwPHBXJlGZmVlFKeQ+m+8Cv5H0BUnHSxqeVVBmZlZZCkk284FbSGpDFwCPSPpTJlGZmVlFKaQZbW1E/EdugaTdBzgeMzOrQIXUbNokNecWRMQbAxyPmZlVoEJqNqOByZK+CDwOLAXaIuL2TCIzM7OKkXeyiYhPwI6ms8OBI4G/B5xszMzsLRVyU+c+wHRgP2A5cEtE3JxVYDZIRCQTW/W0bWZGYX02twGvAr8AaoGHJR2bSVQ2OMycCdOnJwkGksfp05NyM7MchSSbfSPi6oi4Mx2V9iFgbkZxWbmLgI0bYc6cnQln+vRke+PGnQnIzIzCBgi8LOnIiHgCICKelVTb20lWoSSYPTt5PmdO8gPQ3JyUuynNzHL0usTAjgOl8cCPgYeAJ4DDgAMj4iPZhZcdLzEwQCKgJqeC3N7uRGNWwTJbYiDHFuAYksXU9iMZ+nx2oW9oFaSj6SxXbh+OmVmqkGTz04j4W0T8KCJmRsT3gIb+BiBpH0n3SlqZPu7dw3F3S9oo6c4u5eMk/U7SM5IWSNqtvzFZHnL7aJqbkxpNc3PnPhwzs1SvyUbSJyRdBQyTNEFS7jnzBiCGy4D7IuJg4L50uzvfAM7ppvzrwOyIeCfwCnD+AMRkvZFgxIjOfTSzZyfbI0a4Kc3MOslnWegDgZOBbwKPAYcCG0kWUNs3Iv6+XwFITwMnRsQ6SQcAD0TEoT0ceyLwhYj4YLotYD2wf0Rsk/QuYGZEvK+393WfzQDxfTZmVaWvfTa9jkZL1665RdKfIuK36ZuNBOqBFYW+YTdGR8S69PkLJNPi5GsksDEitqXba4EDByAmy1fXxOJEY2bdKGTo8wpJ00gGCjwFPBERr+dzoqSFwP7d7JqRuxERISmzxn5JU4GpAGPHjs3qbczMrItCks1/AQuBacAfgXdJejYixvd2YkRM7mmfpBclHZDTjPZSATFtAEZI2iWt3YwhWUG0pzjmkfYzNTY2ugfbzKxIChmNNiwirgRejIgTSIY9/2gAYrgDmJI+nwL8PN8TI+lw+jVwRl/ONzOz4ij0PhuANyTtERE/Ad47ADFcBfyTpJXA5HQbSY2S/rPjIEkPkcwwfbKktZI6BgF8EbhY0jMkfTjfH4CYzMxsABXSjHZNOvPzAuAGSY8AI/obQERsIBnt1rW8FfiXnO3jezj/WcATgpqZlbF87rN5lyRFxE8i4uWI+CbwK+DtwEczj9DMzAa9fGo25wLXSfojcDdwd0Tckm1YZmZWSfK5z2Ya7JiI8/3ATZKGk3TM3w38NiK2ZxqlmZkNavk0o00AiIgVETE7Ik4B3gM8DHwc+F22IZqZ2WCXTzPaLyX9BrgiIp4DSG/mvCv9MTMze0v5DH0eDzwOPChpjqR9M47JzMwqTK/JJl1W4FvABOA54PeSvippr8yjMzPro5YWqK9P1varr0+2rXTyvqkzIrZExDXAEcDrwGJJX8gsMjOzPmppgalTYfXqZCLy1auTbSec0sk72Uiql3QKyY2WY4FXgX/PKjAzs76aMQM2b+5ctnlzUm6l0esAAUnLSKbtX0OypMAfSBY5+zbJhJxmZmVlzZrCyi17+YxGOx34c/S2ypqZWZkYOzZpOuuu3EojnwECz6brzBws6fuSvl2MwMzM+mrWLKit7VxWW5uUW2kUMuvzrcCPgXcDSDpCkqetMbOy09QE8+ZBXV2yeGxdXbLd1FTqyKpXIbM+10TEryT9O0BEPCnpiIziMjPrl6YmJ5dyUkjN5i+SxgEBIEnAHplEZWY22HTt1nY3dyeFJJuLgO8B+0v6FHAb8GQmUZmZDSYzZ8L06TsTTESyPXNmKaMqK4Xc1LkKOAX4PPAO4DfAOdmEZWY2SETAxo0wZ87OhDN9erK9caNrOKl87rNRx7DniNhGMkjgxz0dY2ZWVSSYPTt5PmdO8gPQ3JyUS6WLrYzkU7P5taQLJXUaoS5pN0nvkXQzMCWb8MzMBoHchNPBiaaTfJLNKcB24IeS/iJpuaQ/AyuBs4FrI+KmDGM0MytvHU1nuXL7cCyvlTq3AN8BviNpV2AU8HpEbMw6ODOzspfbR9PRdNaxDa7hpPLpszkU+GMktgLrsg/LrApFdP5S6rpt5UmCESM699F0NKmNGOF/w5R669eX9ARQRzLp5jLgiY7HiHgp8wgz0tjYGK2traUOwywxc2Yycqnjy6rjr+URIzx8drCokj8WJC2OiMZCz8tnbrQjgX2BacCHSIY9fwlYJumFQt/QzLrw0NnK0DWxVGCi6Y+8pquJiDeAxyT9b0Rc2FEuae/MIjOrFh46a1WgkBkEIJ2qZsdGxCsDGItZ9fLQWatwvSYbSddJOl/SRMC/+WZZ8NBZq3D51GyWAg3AtcCw9D6b2yX9m6Qzsw3PrAp0HTrb3p485vbhmA1y+dxnMy93W9IY4ChgEnAusCCb0MyqhIfOWhXodehzp4OTprSzgbNI7rcZHxHDM4otUx76bGWnSobO2uDW16HP+dzUeQhJgvln4H+BHwEnRMSf02lrzGwgeOisVbB8hj6vAB4DzoiIJ7rsc2OymZn1Kp8BAh8F/gz8t6RbJX0onSNtQEjaR9K9klamj93euyPpbkkbJd3ZpfwmSX+W1Jb+NAxUbGZmNjDymUHgZxFxFvBO4FfAVGCtpBuBvQYghsuA+yLiYOC+dLs736DnxdouiYiG9KdtAGIyM7MBVMhKna9FxA8i4kPAeGARyRxp/XUacHP6/Gbg9B7e/z7g1QF4PzMzK7JCZxAAkpkDImJeRLxnAGIYHREdM0m/AIzuw2vMkrRM0mxJu/d0kKSpklolta5fv75PwZqZWeH6lGwKJWmhpCe7+Tkt97h0aelCBx1cTlLT+jtgH+CLPR2YJsjGiGjcd999C/0YVmpdh+n7ZseiaWmB+nqoqUkeW1pKHZENNnlNxNlfETG5p32SXpR0QESsk3QAUNCyBTm1ojfSfqQv9CNUK1eegr9kWlpg6lTYvDnZXr062QZoaipdXDa4FKVm04s7gCnp8ynAzws5OU1QSBJJf8+TAxqdlV4xpuB3ralHM2bsTDQdNm9Oys3yVdAMApkEII0kuVF0LLAa+EREvCypEfhMRPxLetxDJM1lewIbgPMj4h5J95OstyOgLT3nf3t7X88gMMjkJpgOAzUFv2tNb6mmpvvcKyXTuFl1yWzxtKxFxIaIODkiDo6IyRHxclre2pFo0u3jI2LfiNgjIsZExD1p+Xsi4siIOCIiPplPorFBSOKCNzpPwX/BGwOQaLxwWa/Gji2s3Kw7JU82Zvm4YFpwyPWdp+A/5PrpXDCtn8kgnfRyxfvSWZZramDOnGS7SteT6ToY4NRToba28zG1tTBrVimis8HKycbKXwSHfnc6FzGHa2lGtHMtzVzEHA79bv+n4G/5gZj0YOda06QHZ9Pyg+pMNFOnJoMAIpLHm2+GKVOgri7JvXV1MG+eBwdYYYoyGs2sXyReiRFcSzPTmQ0ofYSN0f8p+Gd8KZj1euda06zXpzPjS7NpaqquhNPTYIC77oJVq0oSUt95Fu2yUvIBAqXiAQKDyy67wPbtQefFYoMhQ8S2bf144Qjm1EynOa01TWc2s0lqUXNoprm9uprSKmYwgAd9ZGbQDhAwy0dyX0fXL33tuN+jzyRi+JtrTdfSTAyvvoXLKmIwgAd9lKeIqMqfSZMmhQ0u06ZFDBkSAcnjtGkD87rz50fU7tEeybdQ8lO7R3vMnz8wrz+YzJ8fUVsbna9FbQy+a9HeHtHc3PmDNDcn5dYvQGv04TvXzWhmJB3jM2bAmjXJX/GzZlVvB3jFXIuIpF2wQ3t71dVUs9DXZjQnGzOrPBGseP90xt+z8ybgFe9rZvyvqqsPLgvuszEzg06JJneo/Ph75rDi/f0fKm9946HPZlZZJO5+dAR3dzNUnkdHMN41m5JwM5qZVZxkCPebh8pLGlxDuMuQm9HMzFLJUO03D5UfVEO4K4yTjQ0eXgbA8jRrludzKzdONjY4zJy58wY92Hmjnu8Gt240NSXzt3k+t/LhZGPlL+eO8BuGT6dGwQ3DfUe4vbWmpmQ+t/b25NGJprQ8Gs3Kn0RL42w2Dgk+++ocPs0ceBWuG/J5RjTOpsmji6w7noizrLhmY4PC+s/9G1u3dy7buj0pN3sTN7uWHScbK38RaNMrXMTcTsUXMRdtesXNaNaZJ+IsS25Gs0Fh2DDg1R7KzXKlq68CSYKZk05Z01y9q6+WA9dsrPxJNE7em+uGfL5T8XVDPk/j5L395WFvlptwOjjRlJSTjQ0KR/3kK5x8cueyk09Oys3epKPpLNd0z4tWSk42Vv7SL47x/z03aQppb4fm5mTbXyDWVW4fTc7vS6c+HCs699lY+ZOS5Xxz29w7mkhGVN9qmtaLjt+XCy/s/PvS3u7flxJysrHBYebMzvdJdHyB+IvDuvPAA7Bp087fmQh46CEYPrzUkVUtN6PZ4NE1sTjRWHfa25NE09bGU0MnUaN2nho6CdraknJP+1wSTjZmVllqami5eDFL1cDhW9toZwiHb21jqRpouXhx56WirWi8no2ZVZz6eli9up1gyI4ysZ26uhpWrSpZWBXB69mYmaXWrG7ncSZ1KnucSaxZ7Sa0UnGyMbPK0t7OE7tOYiJtLKEBsZ0lNDCRNp7YdZL7bErEycasXHhxuIFRU8Oog4azVA0cw2KghmNI+nBGHTTcfTYl4qtuVg48S/GAGv2HB3jy5sXU1dWki6fV8OTNixn9hwdKHVrVKnmykbSPpHslrUwf9+7mmAZJiyQ9JWmZpDNz9o2T9DtJz0haIGm34n4Cs37yLMWZaDqnpvPiaeeU/OuuqpXD1b8MuC8iDgbuS7e72gycGxGHA6cA10oake77OjA7It4JvAKcX4SYzQZOxw2qHVOq1NTsnGrFN65ahSj50GdJTwMnRsQ6SQcAD0TEob2csxQ4A3gGWA/sHxHbJL0LmBkR7+vtfT302cpOROf+hPZ2JxorO4N56PPoiFiXPn8BGP1WB0s6FtgN+BMwEtgYEdvS3WuBA7MK1CwznqXYKlxRko2khZKe7ObntNzjIqlm9fi/K6353Ap8KiIKHr8oaaqkVkmt69evL/hzmGXCsxRbFSjKRJwRMbmnfZJelHRATjPaSz0ctxfwS2BGRDyaFm8ARkjaJa3djAGef4s45gHzIGlG69unMRtgntXaqkA5zPp8BzAFuCp9/HnXA9IRZv8F3BIRP+4oj4iQ9GuS/pvbejrfrOx5VmurcOXQZ3MV8E+SVgKT020kNUr6z/SYTwDvBs6T1Jb+NKT7vghcLOkZkj6c7xc3fLMB4lmtrYKVfDRaqXg0mlkZyq3ddbdtJTeYR6OZmXkWhQrnZGNmpedZFCqek41ZuajmiTilZMnmhobOsyg0NCTlbkob9JxszMpBtTchRexYyrmTjqWcqynxVignG7NScxNSUnP55jd5eWxDp+KXxzbAN7/pmk0FcLIxKzVPxAkRrDj1YvZZ07lms8+aNlacenF1JNwK52RjVg4kWhpndypqaaySRAMgcfei4Syhc81mCQ3cvch9NpXAycasDLTMDzZ+qvNEnBs/NZ2W+VXyF30E+p9NTKSNa2lGtHMtzUykDf2P+2wqgZONWalF8MYF0/nstjmdvmg/u20Ob1xQJRNxSsTwEVxLM9OZDYjpzOZamonhnh+uEpTD3Ghm1U3iuVff/EULsOnV6vmi3fe6mUz914DXOz6vmLHHbOZdVx2fv9J5uhqzMlBfD6tXB5D7xRrU1YlVq0oTUym0tMCMGbBmDYwdC7NmQVNTqaOyXJ6uxmwQmzULams7/wVfWytmzSpRQCXS1ASrViVL+qxa5URTSZxszMpAUxPMmwd1dUmrWV1dsu0vW6sU7rMxKxNNTU4uVrlcszEzs8w52ZiZWeacbMzMLHNONmZmljknGzMzy5yTjZmZZc7JxszMMudkY2ZmmXOyMTOzzDnZmJlZ5pxszMwsc042ZmaWOScbMzPLnJONmZllzsnGzMwy52RjZmaZU0SUOoaSkPQq8HSp4ygTo4C/ljqIMuFrsZOvxU6+FjsdGhHDCj2pmlfqfDoiGksdRDmQ1OprkfC12MnXYidfi50ktfblPDejmZlZ5pxszMwsc9Vus61wAAAF7ElEQVScbOaVOoAy4muxk6/FTr4WO/la7NSna1G1AwTMzKx4qrlmY2ZmRVLxyUbSKZKelvSMpMu62b+7pAXp/t9Jqi9+lNnL4zpcLGm5pGWS7pNUV4o4i6G3a5Fz3MckhaSKHYWUz7WQ9In0d+MpST8odozFksf/kbGSfi1pSfr/5NRSxFkMkm6Q9JKkJ3vYL0lz02u1TNIxvb5oRFTsDzAE+BPwDmA3YClwWJdjLgCuT5+fBSwoddwlug4nAbXp82mVeB3yvRbpccOAB4FHgcZSx13C34uDgSXA3un2fqWOu4TXYh4wLX1+GLCq1HFneD3eDRwDPNnD/lOBXwECjgN+19trVnrN5ljgmYh4NiL+BtwGnNblmNOAm9PnPwZOlqQixlgMvV6HiPh1RGxONx8FxhQ5xmLJ53cC4KvA14EtxQyuyPK5Fv8KXBcRrwBExEtFjrFY8rkWAeyVPh8O/KWI8RVVRDwIvPwWh5wG3BKJR4ERkg54q9es9GRzIPBczvbatKzbYyJiG7AJGFmU6Ionn+uQ63ySv1oqUa/XIm0SeHtE/LKYgZVAPr8XhwCHSPqtpEclnVK06Iorn2sxE/ikpLXAXcCFxQmtLBX6nVLVMwhYNyR9EmgETih1LKUgqQb4JnBeiUMpF7uQNKWdSFLbfVDSkRGxsaRRlcbZwE0R8X8lvQu4VdIREdFe6sAGg0qv2TwPvD1ne0xa1u0xknYhqR5vKEp0xZPPdUDSZGAG8OGIeKNIsRVbb9diGHAE8ICkVSTt0XdU6CCBfH4v1gJ3RMTWiPgz8EeS5FNp8rkW5wM/AoiIRcBQkjnTqlFe3ym5Kj3ZPAYcLGmcpN1IBgDc0eWYO4Ap6fMzgPsj7QGrIL1eB0kTge+SJJpKbZeHXq5FRGyKiFERUR8R9ST9Vx+OiD7NB1Xm8vn/8TOSWg2SRpE0qz1bzCCLJJ9rsQY4GUDSBJJks76oUZaPO4Bz01FpxwGbImLdW51Q0c1oEbFN0ueAe0hGm9wQEU9JuhJojYg7gO+TVIefIekQO6t0EWcjz+vwDWBP4PZ0fMSaiPhwyYLOSJ7XoirkeS3uAd4raTmwHbgkIiqt5p/vtfg/wPckTScZLHBeBf5hCoCkH5L8kTEq7aP6CrArQERcT9JndSrwDLAZ+FSvr1mh18rMzMpIpTejmZlZGXCyMTOzzDnZmJlZ5pxszMwsc042ZmaWOScbszxJ2l/SbZL+JGmxpLskHVLA+eMltaWzBh/Uz1gacmcdlvTht5rB2qzUPPTZLA/p5KyPADen9xkg6Whgr4h4KM/XuAzYJSK+1s1rq5BpTySdRzIb9efyPceslFyzMcvPScDWjkQDEBFLI+IhSSdKurOjXNK302RATtmpwEXAtHRNlPp07ZRbgCeBt0v6f5Ja03Vj/i3n3L+T9IikpZJ+L2k4cCVwZlpTOlPSeZK+nR5fL+l+7VybaGxaflO6Bskjkp6VdEZ2l8usMycbs/wcASzu68kRcRdwPTA7Ik5Kiw8GvhMRh0fEamBGRDQCRwEnSDoqnTplAdAcEUcDk4HXgCtI1hxqiIgFXd7uWyQ1sKOAFmBuzr4DgH8EPghc1dfPY1aoip6uxqzMrU7XAunwCUlTSf5fHkCyQFcA6yLiMYCI+B+AXpZcehfw0fT5rcDVOft+ljbXLZc0ekA+hVkeXLMxy89TwKQe9m2j8/+loXm+5msdTySNA74AnJzWSH5ZwOsUInc270pbJNDKmJONWX7uB3ZPax4ApM1cxwOrgcMk7S5pBOnMwAXaiyT5bEprHO9Py58GDpD0d+l7DkuXwniVZDmE7jzCzgllm4C8BjCYZcnJxiwP6ey+HwEmp0OfnwL+A3ghIp4jWefkyfRxSR9ef2l63grgB8Bv0/K/AWcC35K0FLiXpMbza5IE1ybpzC4vdyHwKUnLgHOA5kLjMRtoHvpsZmaZc83GzMwy52RjZmaZc7IxM7PMOdmYmVnmnGzMzCxzTjZmZpY5JxszM8uck42ZmWXu/wMJrhHbANuKxAAAAABJRU5ErkJggg==
 "
 >
 </div>
@@ -12531,8 +13855,7 @@ Found 16 PIFs
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <h3 id="Filter-by-value">Filter by value<a class="anchor-link" href="#Filter-by-value">&#182;</a></h3><p>A few of the values in are mislabeled: they are called "Enthalpy of Formation" but are actually total energies (per atom).  We can filter them out by recognizing that all the Al-Cu binaries have enthalpy of formation above $-1.0 eV / $atom.</p>
 
@@ -12541,10 +13864,10 @@ Found 16 PIFs
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[18]:</div>
+<div class="prompt input_prompt">In&nbsp;[21]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">query</span> <span class="o">=</span> <span class="n">PifSystemReturningQuery</span><span class="p">(</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">query</span> <span class="o">=</span> <span class="n">PifSystemReturningQuery</span><span class="p">(</span>
             <span class="n">size</span><span class="o">=</span><span class="mi">500</span><span class="p">,</span>
             <span class="n">query</span><span class="o">=</span><span class="n">DataQuery</span><span class="p">(</span>
                 <span class="n">system</span><span class="o">=</span><span class="n">PifSystemQuery</span><span class="p">(</span>
@@ -12562,20 +13885,20 @@ Found 16 PIFs
                 <span class="p">)</span>
             <span class="p">))</span>
 
-<span class="n">query_result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
+<span class="n">query_result</span> <span class="o">=</span> <span class="n">client</span><span class="o">.</span><span class="n">search</span><span class="o">.</span><span class="n">pif_search</span><span class="p">(</span><span class="n">query</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[19]:</div>
+<div class="prompt input_prompt">In&nbsp;[22]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">new_points</span> <span class="o">=</span> <span class="p">[]</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">new_points</span> <span class="o">=</span> <span class="p">[]</span>
 <span class="k">for</span> <span class="n">hit</span> <span class="ow">in</span> <span class="n">query_result</span><span class="o">.</span><span class="n">hits</span><span class="p">:</span>
     <span class="n">n_Al</span><span class="p">,</span> <span class="n">n_Cu</span> <span class="o">=</span> <span class="n">get_stoich</span><span class="p">(</span><span class="n">hit</span><span class="o">.</span><span class="n">extracted</span><span class="p">[</span><span class="s2">&quot;formula&quot;</span><span class="p">])</span>
     <span class="n">new_points</span><span class="o">.</span><span class="n">append</span><span class="p">((</span>
@@ -12584,14 +13907,13 @@ Found 16 PIFs
         <span class="p">))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
 </div>
 <div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
-</div>
-<div class="inner_cell">
+</div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>This looks much better:</p>
 
@@ -12600,10 +13922,10 @@ Found 16 PIFs
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[20]:</div>
+<div class="prompt input_prompt">In&nbsp;[23]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">plt</span><span class="o">.</span><span class="n">scatter</span><span class="p">(</span><span class="o">*</span><span class="nb">zip</span><span class="p">(</span><span class="o">*</span><span class="n">points</span><span class="p">),</span> <span class="n">color</span><span class="o">=</span><span class="s1">&#39;blue&#39;</span><span class="p">,</span> <span class="n">marker</span><span class="o">=</span><span class="s1">&#39;o&#39;</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;alloyDB&#39;</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">plt</span><span class="o">.</span><span class="n">scatter</span><span class="p">(</span><span class="o">*</span><span class="nb">zip</span><span class="p">(</span><span class="o">*</span><span class="n">points</span><span class="p">),</span> <span class="n">color</span><span class="o">=</span><span class="s1">&#39;blue&#39;</span><span class="p">,</span> <span class="n">marker</span><span class="o">=</span><span class="s1">&#39;o&#39;</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;alloyDB&#39;</span><span class="p">)</span>
 <span class="n">plt</span><span class="o">.</span><span class="n">scatter</span><span class="p">(</span><span class="o">*</span><span class="nb">zip</span><span class="p">(</span><span class="o">*</span><span class="n">new_points</span><span class="p">),</span> <span class="n">color</span><span class="o">=</span><span class="s1">&#39;red&#39;</span><span class="p">,</span> <span class="n">marker</span><span class="o">=</span><span class="s1">&#39;x&#39;</span><span class="p">,</span> <span class="n">label</span><span class="o">=</span><span class="s1">&#39;citrination (filtered)&#39;</span><span class="p">)</span>
 <span class="n">plt</span><span class="o">.</span><span class="n">legend</span><span class="p">()</span>
 <span class="n">plt</span><span class="o">.</span><span class="n">xlim</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span>
@@ -12611,7 +13933,7 @@ Found 16 PIFs
 <span class="n">plt</span><span class="o">.</span><span class="n">ylabel</span><span class="p">(</span><span class="s2">&quot;$\Delta H (eV/atom)$&quot;</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -12621,32 +13943,45 @@ Found 16 PIFs
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[20]:</div>
+    <div class="prompt output_prompt">Out[23]:</div>
 
 
 
 
 <div class="output_text output_subarea output_execute_result">
-<pre>Text(0,0.5,u&#39;$\\Delta H (eV/atom)$&#39;)</pre>
+<pre>Text(0,0.5,&#39;$\\Delta H (eV/atom)$&#39;)</pre>
 </div>
 
 </div>
 
 <div class="output_area">
 
-<div class="prompt"></div>
+    <div class="prompt"></div>
 
 
 
 
 <div class="output_png output_subarea ">
-<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvNQv5yAAAIABJREFUeJzt3X18VNW97/HPL0jFtEhQEXlJSdD6gDwFkuMRW0SEWmqrotVaT6pw9Jy8ig+N8dZqD6dK28s5WnsNQem1aVVQUqVqW7mt1YpKfcQaavCBgqASRK1GFI4aUSC/+8feSWbChMwk2TOTyff9es1rZq+99+zfbIb5Ze219lrm7oiIiEQpL9MBiIhI7lOyERGRyCnZiIhI5JRsREQkcko2IiISOSUbERGJnJKNiIhETslGREQip2QjIiKR2yfTAWTKQQcd5EVFRZkOQ0SkV1m9evW77j4k1f36bLIpKiqirq4u02GIiPQqZtbQlf10GU1ERCKnZCMiIpFTshERkcj12TYbEWmzc+dOtmzZwo4dOzIdimSJAQMGMHz4cPr3798j76dkIyJs2bKFgQMHUlRUhJllOhzJMHdn69atbNmyhZEjR/bIe+oymoiwY8cODjzwQCUaAcDMOPDAA3u0pqtkIyIASjQSp6e/D0o2IiISOSUbEclaRUVFvPvuuwB87nOf69J7rFy5kkGDBjFhwgSOOuooTjjhBP7whz+0rp83bx6HHnooxcXFHH300cyZM4fm5uYeiV/aKNmISM6bPHkyzz33HOvXr2fhwoVccsklPPzww63rKysrqa+vZ+3atbzwwgv85S9/yWC0uUnJRkRSVlsLRUWQlxc819Z2/z1nzpxJSUkJo0ePpqampsPt3J0rrriCMWPGMHbsWJYtWwbA+eefz+9///vW7crKyrjvvvv22L+4uJirr76am266aY91n376KTt27GDw4MHd/0ASR8lGRFJSWwvl5dDQAO7Bc3l59xPOrbfeyurVq6mrq2PhwoVs3bo14Xa//e1vqa+vZ82aNaxYsYIrrriCt956iwsvvJDFixcDsH37dp566im+9rWvJXyPiRMnsm7dutblqqoqiouLGTZsGEceeSTFxcXd+zCyByUbEUnJ3LnQ1BRf1tQUlHfHwoULGT9+PMcddxyvv/46GzZsSLjdE088wbnnnku/fv0YOnQoU6ZM4dlnn2XKlCls2LCBxsZG7rzzTr7xjW+wzz6JbyV097jllsto77zzDh999BF33XVX9z6M7EHJRkRSsnlzauXJWLlyJStWrODpp59mzZo1TJgwoUv3eJx//vksXbqU2267jQsuuKDD7Z577jlGjRq1R3n//v2ZMWMGjz32WMrHlr1TshGRlIwYkVp5MrZv387gwYPJz89n3bp1rFq1qsNtJ0+ezLJly9i9ezeNjY089thjHHvssQDMnj2bBQsWAHDMMcck3P/555/nJz/5CRdffPEe69ydJ598ksMPP7zrH0YS0nA1IpKS+fODNprYS2n5+UF5V82YMYObb76ZUaNGcdRRR3Hcccd1uO0ZZ5zB008/zfjx4zEzfvrTn3LIIYcAMHToUEaNGsXMmTPj9nn88ceZMGECTU1NHHzwwSxcuJBp06a1rq+qqmLp0qXs3LmTcePGcdFFF3X9w0hi7p4VD2AGsB7YCFyVYP2+wLJw/TNAUcy6H4Tl64GvJHe8Ei8sdF+61EX6vLVr16a0/dKl7oWF7maeVf+PPvroIz/ssMN827ZtmQ4lJ8R+L1r+zaHEvQu/8VlxGc3M+gGLgK8CxwDnmln7OvCFwPvu/gWgCrgu3PcY4FvAaIKE9fPw/TrVU71oRPqasjLYtAmam4PnsrJMRwQrVqxg1KhRXHrppQwaNCjT4eSU2B6IXZUVyQY4Ftjo7q+6+6fAXcDp7bY5HVgSvr4HmGbB4D2nA3e5+yfu/hpBDefYZA/cE71oRCTzpk+fTkNDA5dddlmmQ8k5iXogpipbks2hwOsxy1vCsoTbuPsuYDtwYJL7AmBm5WZWZ2Z10Nha3p1eNCIiua4nfiOzJdmkhbvXuHupu5fCkNby7vSiERHJdT3xG5ktyeYN4PMxy8PDsoTbmNk+wCBga5L7dqi7vWhERHLd/PnBb2V3ZEuyeRY4wsxGmtlnCBr8l7fbZjkwK3x9FvCIu3tY/i0z29fMRgJHAH9N5qCFhVBTkx2NmyIi2aqsLPitLCzs+ntkRbIJ22AuAR4E/g78xt1fMrMfm9lp4Wa3AAea2UbgcuCqcN+XgN8Aa4EHgIvdfXdnxywpyZ5eNCKS2M0338ztt98OwOLFi3nzzTc73Pbqq69mxYoVXTpOfX09999/f+vy8uXLufbaa7v0Xu19/PHHTJkyhd27g5+lK664gtGjR3PFFVfEfb7Zs2dzzz33ALBgwQKautsivxct0zU0NjYyY8aMpPZp6YEIq1d36aBd6S+dC4+SkpJOepiL9B2p3mfjzc17X47AlClT/Nlnn024bteuXd1679tuu80vvvjibr1HR2666SZfsGBB6/L++++fMN5Zs2b53Xff7e7uhYWF3tjYmNJxUjkHn/3sZ1tfz54925944omE2yX6XgB13lvvsxGRXmTePKisDIZ8huC5sjIo74bbb7+dcePGMX78eM4777zwUPP42c9+xj333ENdXR1lZWUUFxfz8ccfU1RUxJVXXsnEiRO5++6742oGRUVFXHPNNUycOJGxY8e2jvD817/+lUmTJjFhwgSOP/541q9fz6effsrVV1/NsmXLKC4uZtmyZSxevJhLLrkEgE2bNnHSSScxbtw4pk2bxuawa9bs2bP57ne/y/HHH89hhx3Weuz2amtrOf304E6O0047jQ8//JCSkhKWLVvW+vliLVy4kDfffJOpU6cydepUAP785z8zadIkJk6cyNlnn82HH37Y+jljz8Err7zCjBkzKCkpYfLkya2f+7XXXmPSpEmMHTuW//zP/4w73syZM6lNx82GXclQufBQzUakTdI1m+Zm94oKdwieEy13wYsvvuhHHHFE61/zW7dudXf3a665xq+//np337NmU1hY6Nddd13rcvuawcKFC93dfdGiRX7hhRe6u/v27dt9586d7u7+0EMP+Zlnnunue9ZsYpe//vWv++LFi93d/ZZbbvHTTz+99XhnnXWW796921966SU//PDD9/hcn3zyiQ8dOjSuLLZWEfv5OqrZNDY2+uTJk/3DDz90d/drr73Wf/SjHyU8ByeddJK//PLL7u6+atUqnzp1qru7n3rqqb5kyRJ3D2pasTFs2bLFx4wZs0fs7j1bs9HYaCKSPDOoqgpeV1cHD4CKiqDcrEtv+8gjj3D22Wdz0EEHAXDAAQcktd8555zT4bozzzwTgJKSEn77298CwYCfs2bNYsOGDZgZO3fu7PQYTz/9dOv+5513Ht///vdb182cOZO8vDyOOeYY3n777T32fffddykoKEjqs3Rk1apVrF27li9+8YtAMMHbpEmTWte3nIMPP/yQp556irPPPrt13SeffALAk08+yb333tv6Ga688srWbQ4++OC9toX1FCUbEUlNS8JpSTTQrUTTHZ/97Gc7XLfvvvsC0K9fP3bt2gXAD3/4Q6ZOncrvfvc7Nm3axIknntit47ccA/acIwdgv/3269JUCbHcnS9/+cvceeedCde3nIPm5mYKCgqor69PuJ118O+zY8cO9ttvv27FmAy12YhIalraaGLFtuF0wUknncTdd9/dOjvne++9t8c2AwcO5IMPPujyMSCo2Rx6aDDASMusnp299/HHH986mVptbS2TJ09O+niDBw9m9+7dKSec2HiOO+44nnzySTZu3AjARx99xMsvv7zHPvvvvz8jR47k7rvvBoIktWbNGgC++MUvxn2GWC+//DJjxoxJKb6uULIRkeS1JJrq6uDSWXNz8Fxd3a2EM3r0aObOncuUKVMYP348l19++R7bzJ49m+985zutHQS64vvf/z4/+MEPmDBhQmttB2Dq1KmsXbu2tYNArBtvvJHbbruNcePGcccdd1AdW6NLwsknn8wTTzyR0j7l5eXMmDGDqVOnMmTIEBYvXsy5557LuHHjmDRpUtyU1rFqa2u55ZZbGD9+PKNHj+a+++4DoLq6mkWLFjF27FjeeCP+nvdHH320w+mze5Ilqvr1BaWlpV5XV5fpMESywt///veEM1cmNG8ebNvWdumsJQEVFHS7R1ou+tvf/kZVVRV33HFHpkNJ6IQTTuC+++5j8ODBe6xL9L0ws9XuXprqcdRmIyKpmTcvSDAtbQAtbTgZaLPpDSZOnMjUqVPZvXs3/folNftJ2jQ2NnL55ZcnTDQ9TclGRFLXPrEo0ezVBRdckOkQEhoyZMges5pGRW02IgIk7k0lfVdPfx+UbESEAQMGsHXrViUcAYJEs3XrVgYMGNBj76nLaCLC8OHD2bJlC42NjZ1vLH3CgAEDGD58eI+9n5KN9B6xjdKJlqXL+vfvz8iRIzMdhuQwXUaT3iGiwR9FJD2UbCT7uQf3dcTeONhyY+G2bd26c11E0kOX0ST7RTT4o4ikj0YQkN7DHfJiKuPNzUo0ImnW1REEdBlNeocIBn/MNrW1UFQU5NOiomBZJFco2Uj2i2jwx2xSWwvl5dDQEHychoZgWQlHcoXabCT7mQWDPMa20bS04RQU5MSltLlzoakpvqypKSgvK8tMTCI9SW020nvk8H02eXmJK2hmQUVOJFuozUZyXw4P/jhiRGrlIr2Nko1IFpg/H/Lz48vy84NykVygZCOSBcrKoKYGCguDClthYbCs9hrJFeogIJIlysqUXCR3qWYjIiKRU7IREZHIKdmIiEjklGxERCRySjYiIhI5JRsREYlcxpONmR1gZg+Z2YbweXAH280Kt9lgZrNiylea2Xozqw8fB6cvehERSUbGkw1wFfCwux8BPBwuxzGzA4BrgH8GjgWuaZeUyty9OHy8k46gRUQkedmQbE4HloSvlwAzE2zzFeAhd3/P3d8HHgJmpCk+ERHppmxINkPd/a3w9T+AoQm2ORR4PWZ5S1jW4rbwEtoPzXJodEYRkRyRluFqzGwFcEiCVXNjF9zdzSzVOQ/K3P0NMxsI3AucB9zeQRzlQDnACA2nKyKSNmlJNu4+vaN1Zva2mQ1z97fMbBiQqM3lDeDEmOXhwMrwvd8Inz8ws18TtOkkTDbuXgPUQDCfTeqfREREuiIbLqMtB1p6l80C7kuwzYPAyWY2OOwYcDLwoJntY2YHAZhZf+DrwItpiFlERFKQDcnmWuDLZrYBmB4uY2alZvYrAHd/D/gJ8Gz4+HFYti9B0nkeqCeoAf0y/R9BRET2RtNCi4hI0jQttIiIZC0lGxERiZySjYiIRE7JRkREIqdkIyIikVOyERGRyCnZiIhI5JRsRCRjamuhqAjy8oLn2tpMRyRRScvYaCIi7dXWQnk5NDUFyw0NwTJAWVnm4pJoqGYjIhkxd25bomnR1BSUS+5RshGRjNi8ObVy6d1STjZm9lkz6xdFMCLSd3Q0pZSmmspNnSYbM8szs38xsz+a2TvAOuAtM1trZteb2ReiD1NEcs38+ZCfH1+Wnx+US+5JpmbzKHA48APgEHf/vLsfDHwJWAVcZ2bfjjBGEclBZWVQUwOFhWAWPNfUqHNArup0igEz6+/uO7u7TbbRFAMiIqmLbIqB2CQSzoa5121ERETaS/o+m3DWzK+Z2S7gTeB54Hl3vzGq4EREJDekclPnZGC4u+82s0OB8cC4aMISEZFckkqyeQY4EHjH3d8A3gDujyQqERHJKancZ/ML4C9m9j0zm2xmg6IKSkREcksqyWYpcDtBbegi4CkzeyWSqEREJKekchlti7v/d2yBme3bw/GIiEgOSqVmU29mFbEF7v5JD8cjIiI5KJWazVBgupldCfwNWAPUu/vdkUQmIiI5I+lk4+7fhNZLZ6OBscA/A0o2IiKyV6nc1HkAUAkcDKwFbnf3JVEFJr2EezCwVUfLIiKk1mZzF/AB8P+AfOAJMzs2kqikd5g3DyorgwQDwXNlZVAuIhIjlWQzxN1/6u5/CHulnQosjCguyXbusG0bVFe3JZzKymB527a2BCQiQmodBN4zs7Hu/gKAu79qZvmd7SQ5ygyqqoLX1dXBA6CiIijXpTQRidHpFAOtG5odDdwDPA68ABwDHOruZ0QXXnQ0xUAPcYe8mApyc7MSjUgOi2yKgRg7gIkEk6kdTND1+dxUDyg5pOXSWazYNhwRkVAqyea37v6pu//G3ee5+y+B4u4GYGYHmNlDZrYhfB7cwXYPmNk2M/tDu/KRZvaMmW00s2Vm9pnuxiRJiG2jqagIajQVFfFtOCIioU6TjZl908yuBQaa2Sgzi92npgdiuAp42N2PAB4OlxO5HjgvQfl1QJW7fwF4H7iwB2KSzphBQUF8G01VVbBcUKBLaSISJ5lpoQ8FpgE3AM8CRwHbCCZQG+Lu/9ytAMzWAye6+1tmNgxY6e5HdbDticD33P3r4bIBjcAh7r7LzCYB89z9K50dV202PUT32Yj0KV1ts+m0N1o4d83tZvaKuz8ZHuxAoAhYl+oBExjq7m+Fr/9BMCxOsg4Etrn7rnB5C3BoD8QkyWqfWJRoRCSBVLo+rzOzOQQdBV4CXnD3j5PZ0cxWAIckWDU3dsHd3cwiu9hvZuVAOcCIESOiOoyIiLSTSrL5HbACmAO8DEwys1fd/ejOdnT36R2tM7O3zWxYzGW0d1KIaStQYGb7hLWb4QQziHYURw1hO1NpaalasEVE0iSV3mgD3f3HwNvuPoWg2/NveiCG5cCs8PUs4L5kd/SgwelR4Kyu7C8iIumR6n02AJ+Y2X7ufi9wcg/EcC3wZTPbAEwPlzGzUjP7VctGZvY4wQjT08xsi5m1dAK4ErjczDYStOHc0gMxiYhID0rlMtrPwpGflwG3mtlTQEF3A3D3rQS93dqX1wH/FrM8uYP9XwU0IKiISBZL5j6bSWZm7n6vu7/n7jcAfwI+D5wZeYQiItLrJVOzOR9YZGYvAw8AD7j77dGGJSIiuSSZ+2zmQOtAnF8FFpvZIIKG+QeAJ919d6RRiohIr5bMZbRRAO6+zt2r3H0GcBLwBHA28Ey0IYqISG+XzGW0P5rZX4Cr3f11gPBmzvvDh4iIyF4l0/X5aOBvwGNmVm1mQyKOSUREckynySacVuBGYBTwOvBXM/uJme0feXQiIl1UWwtFRcHcfkVFwbJkTtI3dbr7Dnf/GTAG+BhYbWbfiywyEZEuqq2F8nJoaAgGIm9oCJaVcDIn6WRjZkVmNoPgRssRwAfAf0UVmIhIV82dC01N8WVNTUG5ZEanHQTM7HmCYfs3E0wp8HeCSc5uIhiQU0Qkq2zenFq5RC+Z3mgzgde8s1nWRESyxIgRwaWzROWSGcl0EHg1nGfmCDO7xcxuSkdgIiJdNX8+5OfHl+XnB+WSGamM+nwHcA9wAoCZjTEzDVsjIlmnrAxqaqCwMJg8trAwWC4ry3RkfVcqoz7nufufzOy/ANz9RTMbE1FcIiLdUlam5JJNUqnZvGlmIwEHMDMD9oskKhGR3qZ9s7aaueOkkmwuA34JHGJm/wrcBbwYSVQiIr3JvHlQWdmWYNyD5XnzMhlVVknlps5NwAzgu8BhwF+A86IJS0Skl3CHbdugurot4VRWBsvbtqmGE0rmPhtr6fbs7rsIOgnc09E2IiJ9ihlUVQWvq6uDB0BFRVBulrnYskgyNZtHzexSM4vroW5mnzGzk8xsCTArmvBERHqB2ITTQokmTjLJZgawG7jTzN40s7Vm9hqwATgXWODuiyOMUUQku7VcOosV24YjSc3UuQP4OfBzM+sPHAR87O7bog5ORCTrxbbRtFw6a1kG1XBCybTZHAW87IGdwFvRh5VG7voiiEjXmUFBQXwbTcsltYIC/b6ErLN2fTN7ASgkGHTzeeCFlmd3fyfyCCNSWlrqdc8+G/wFUlCgLooi0j3t/3DN0T9kzWy1u5emul8yY6ONBYYAc4BTCbo9/wfwvJn9I9UDZhV1TxSRntI+seRgoumOTms2cRubvebuI2OWB7v7+5FEFrFSM68DdU8UEUlBZDWbduIyU29NNHGUaEREItdpsjGzRWZ2oZlNAHLvV1ndE0VEIpfMqM9rgGLgfGCgma0FXgLWAmvdfVmE8UWnpAS+9CV1TxQRSYNk7rOpiV02s+HAOKCEIAH1zmQD6p4oIpImqcxnQ3gp7VzgWwT32xwdRVBp09IfXolGRCRSydzUeSRBgvkX4EPgN8AUd38tHLamd1OiERGJXDI1m3XAs8BZ7v5Cu3VqWRcRkU4l0/X5TOA14M9mdoeZnRqOkdYjzOwAM3vIzDaEz4M72O4BM9tmZn9oV77YzF4zs/rwUdxTsYmISM9IZgSB37v7t4AvAH8CyoEtZnYbsH8PxHAV8LC7HwE8HC4ncj0dT9Z2hbsXh4/6HohJRER6UCozdX7k7r9291MJOgY8TTBGWnedDiwJXy8BZnZw/IeBD3rgeCIikmapjiAABCMHuHuNu5/UAzEMdfeWkaT/AQztwnvMN7PnzazKzPbtaCMzKzezOjOra2xs7FKwIiKSui4lm1SZ2QozezHB4/TY7cKppVPtdPADgprWPwEHAFd2tGGYIEvdvXTIkCGpfgzJtPYjPWjkh7SprYWiIsjLC55razMdkfQ2Kd1n01XuPr2jdWb2tpkNc/e3zGwYkNK0BTG1ok/CdqTvdSNUyVbz5gWjc7fcF9UyYZWmh4hcbS2Ul0NTU7Dc0BAsA5SVZS4u6V3SUrPpxHJgVvh6FnBfKjuHCQozM4L2nhd7NDrJPPcg0VRXt41l19PTQ6jW1KG5c9sSTYumpqBcJFkpTTEQSQBmBxLcKDoCaAC+6e7vmVkp8B13/7dwu8cJLpd9DtgKXOjuD5rZIwTz7RhQH+7zYWfHLS0t9bq6ukg+k0QgNsG06KnpIVRr2qu8vMS51wyam9Mfj2RWuqYY6HHuvtXdp7n7Ee4+3d3fC8vrWhJNuDzZ3Ye4+37uPtzdHwzLT3L3se4+xt2/nUyikV7IjIs+qYoruuiTHkg06ag19XIjRqRWLpJIxpONSDIumuMceXNlXNmRN1dy0ZxuJoNwfLx1X6kIEkxeHlRXB8t9dNy89p0BTjkF8vPjt8nPh/nzMxGd9FZKNpL93DnqF5VcRjULqMBoZgEVXEY1R/2i+/MR1f7aKHksvtZU8lgVtb/um4mmvDzoBOAePC9ZArNmQWFhkHsLC6GmRp0DJDVp6Y0m0i1mvO8FLKCCSqoAC59hm3d/eoi5/+HM/zi+1jT/40rm/kcVZWV9K+F01Bng/vth06aMhNR17vHfjfbLklYZ7yCQKeog0Lvssw/s3u3ETxbr9Otn7NrVjTd2pzqvkoqw1lRJFVUEtahqKqho7luX0nKmM4A6fUSm13YQEElGcF9H+x99a73fo8vM8EF71poWUIEP6nuT6uVEZwB1+shO7t4nHyUlJS69y5w57v36uUPwPGdOz7zv0qXu+fs1e/ArFDzy92v2pUt75v17k6VL3fPzPf5c5HvvOxfNze4VFfEfpKIiKJduAeq8C7+5uowmQtAwPncubN4c/BU/f37fbQDPmXPhHlwXbNHc3OdqqlHo6mU0JRsRyT3urPtqJUc/2HYT8LqvVHD0n/pWG1wU1GYjIgJxiSa2q/zRD1az7qvd7yovXaOuzyKSW8x4YFUBDyToKs+qAo5WzSYjdBlNRHJO0IV7z67yZta7unBnIV1GExEJBV219+wq36u6cOcYJRvpPTQNgCRp/nyN55ZtlGykd5g3r+0GPWi7UU93g0sCZWXB+G0azy17KNlI9ou5I/zWQZXkmXPrIN0RLntXVhaM59bcHDwr0WSWeqNJ9jOjtrSKbf2ciz+o5gKq4QNY1O+7FJRWUabeRZKIBuLMKqrZSK/QeMmP2Lk7vmzn7qBcZA+67Jp1lGwk+7lj29/nMhbGFV/GQmz7+7qMJvE0EGdW0mU06RUGDgQ+6KBcJFY4+yoQJJjqcMiair47+2o2UM1Gsp8ZpdMHs6jfd+OKF/X7LqXTB+vHQ/YUm3BaKNFklJKN9Arj7r2GadPiy6ZNC8pF9tBy6SxWpcZFyyQlG8l+4Q/H0X9eGFwKaW6GiopgWT8g0l5sG03M9yWuDUfSTm02kv3Mgul8Y6+5t1wiKeh7s2lKJ1q+L5deGv99aW7W9yWDlGykd5g3L/4+iZYfEP1wSCIrV8L27W3fGXd4/HEYNCjTkfVZuowmvUf7xKJEI4k0NweJpr6elwaUkGfNvDSgBOrrg3IN+5wRSjYiklvy8qi9fDVrrJjRO+tpph+jd9azxoqpvXx1/FTRkjaaz0ZEck5RETQ0NOP0ay0zdlNYmMemTRkLKydoPhsRkdDmhmb+Rklc2d8oYXODLqFlipKNiOSW5mZe6F/CBOp5jmKM3TxHMROo54X+JWqzyRAlmz56GVEkZ+XlcdDhg1hjxUxkNZDHRII2nIMOH6Q2mwzp22ddI8GK5KShf1/Ji0tWU1iYF06elseLS1Yz9O8rMx1an5XxZGNmB5jZQ2a2IXwenGCbYjN72sxeMrPnzeycmHUjzewZM9toZsvM7DNJH1wjwYrkrLLz8uInTzsv4z93fVo2nP2rgIfd/Qjg4XC5vSbgfHcfDcwAFphZQbjuOqDK3b8AvA9cmNRRV69uG85CNweKiEQq412fzWw9cKK7v2Vmw4CV7n5UJ/usAc4CNgKNwCHuvsvMJgHz3P0rnR231MzrIPizR4lGRCQpvbnr81B3fyt8/Q9g6N42NrNjgc8ArwAHAtvcfVe4egtwaEpH18B8IiKRS8vYaGa2Ajgkwaq5sQvu7mbW4S9/WPO5A5jl7s2WYo3EzMqBcoARI0bAGWe0TaykS2kiIpFJS7Jx9+kdrTOzt81sWMxltHc62G5/4I/AXHdfFRZvBQrMbJ+wdjMceGMvcdQANRCMIKCRg0VE0iMbRn1eDswCrg2f72u/QdjD7HfA7e5+T0t5WBN6lKD95q6O9u+QRg4WEUmLbGizuRb4spltAKaHy5hZqZn9Ktzmm8AJwGwzqw/VPNUHAAAIfUlEQVQfxeG6K4HLzWwjQRvOLSkdXYlGRCRyGe+NlikaiFMkC8XOWZRoWTKuN/dGExEJRvKI7R2qET5yipKNiGSeezCSR3V1W8LRCB85JRs6CGSWqukimWcWTNlcXBwkmJZbEoqLg3L9H+31+nbNRtV0kezg3jqVc5yWqZxVs+n1+nayUTVdJDuYwQ038N6I4rji90YUww03qGaTA/pustFAnCLZw511p1zOAZvjazYHbK5n3SmX64/BHNB3k00LJRrJErW1UFQUzO1VVBQs9xlmPPD0IJ4jvmbzHMU88LTabHKBko0G4pQsUFsL5eXQ0BB8HRsaguU+k3Dcsf/ZzgTqWUAFRjMLqGAC9dj/qM0mF/Td3mglJfClL2kgTskKc+dCU1N8WVNTUF5WlpmY0soMH1TAgu0VVFIFWPgMDNLYhbmg7yYbQANxSrbYvDm18lw0ZNE8yv/d4eOW/4vG3P2qqFmk/5u5oG8nGw3EKVlixIjg0lmi8r4iqMEZc+cGSXbECJg/3/pGza4PUJuNEo1kgfnzIT8/viw/PyjvS8rKYNOmYALdTZv6yCXEPkLJRiQLlJVBTQ0UFgZ//xQWBsv6sZVc0bcvo4lkkbIyJRfJXarZiIhI5JRsREQkcko2IiISOSUbERGJnJKNiIhETslGREQip2QjIiKRU7IREZHIKdmIiEjklGxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCKnZCMiIpFTshERkciZu2c6howwsw+A9ZmOI0scBLyb6SCyhM5FG52LNjoXbY5y94Gp7tSXZ+pc7+6lmQ4iG5hZnc5FQOeijc5FG52LNmZW15X9dBlNREQip2QjIiKR68vJpibTAWQRnYs2OhdtdC7a6Fy06dK56LMdBEREJH36cs1GRETSJOeTjZnNMLP1ZrbRzK5KsH5fM1sWrn/GzIrSH2X0kjgPl5vZWjN73sweNrPCTMSZDp2di5jtvmFmbmY52wspmXNhZt8Mvxsvmdmv0x1juiTxf2SEmT1qZs+F/09OyUSc6WBmt5rZO2b2YgfrzcwWhufqeTOb2OmbunvOPoB+wCvAYcBngDXAMe22uQi4OXz9LWBZpuPO0HmYCuSHr+fk4nlI9lyE2w0EHgNWAaWZjjuD34sjgOeAweHywZmOO4PnogaYE74+BtiU6bgjPB8nABOBFztYfwrwJ8CA44BnOnvPXK/ZHAtsdPdX3f1T4C7g9HbbnA4sCV/fA0wzM0tjjOnQ6Xlw90fdvSlcXAUMT3OM6ZLMdwLgJ8B1wI50BpdmyZyLfwcWufv7AO7+TppjTJdkzoUD+4evBwFvpjG+tHL3x4D39rLJ6cDtHlgFFJjZsL29Z64nm0OB12OWt4RlCbdx913AduDAtESXPsmch1gXEvzVkos6PRfhJYHPu/sf0xlYBiTzvTgSONLMnjSzVWY2I23RpVcy52Ie8G0z2wLcD1yantCyUqq/KX16BAFJwMy+DZQCUzIdSyaYWR5wAzA7w6Fki30ILqWdSFDbfczMxrr7toxGlRnnAovd/f+Y2STgDjMb4+7NmQ6sN8j1ms0bwOdjloeHZQm3MbN9CKrHW9MSXfokcx4ws+nAXOA0d/8kTbGlW2fnYiAwBlhpZpsIrkcvz9FOAsl8L7YAy919p7u/BrxMkHxyTTLn4kLgNwDu/jQwgGDMtL4oqd+UWLmebJ4FjjCzkWb2GYIOAMvbbbMcmBW+Pgt4xMMWsBzS6XkwswnALwgSTa5el4dOzoW7b3f3g9y9yN2LCNqvTnP3Lo0HleWS+f/xe4JaDWZ2EMFltVfTGWSaJHMuNgPTAMxsFEGyaUxrlNljOXB+2CvtOGC7u7+1tx1y+jKau+8ys0uABwl6m9zq7i+Z2Y+BOndfDtxCUB3eSNAg9q3MRRyNJM/D9cDngLvD/hGb3f20jAUdkSTPRZ+Q5Ll4EDjZzNYCu4Er3D3Xav7Jnov/BfzSzCoJOgvMzsE/TAEwszsJ/sg4KGyjugboD+DuNxO0WZ0CbASagH/t9D1z9FyJiEgWyfXLaCIikgWUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRiRJZnaImd1lZq+Y2Wozu9/Mjkxh/6PNrD4cNfjwbsZSHDvqsJmdtrcRrEUyTV2fRZIQDs76FLAkvM8AMxsP7O/ujyf5HlcB+7j7/07w3pbKsCdmNptgNOpLkt1HJJNUsxFJzlRgZ0uiAXD3Ne7+uJmdaGZ/aCk3s5vCZEBM2SnAZcCccE6UonDulNuBF4HPm9n/NbO6cN6YH8Xs+09m9pSZrTGzv5rZIODHwDlhTekcM5ttZjeF2xeZ2SPWNjfRiLB8cTgHyVNm9qqZnRXd6RKJp2QjkpwxwOqu7uzu9wM3A1XuPjUsPgL4ubuPdvcGYK67lwLjgClmNi4cOmUZUOHu44HpwEfA1QRzDhW7+7J2h7uRoAY2DqgFFsasGwZ8Cfg6cG1XP49IqnJ6uBqRLNcQzgXS4ptmVk7w/3IYwQRdDrzl7s8CuPv/AHQy5dIk4Mzw9R3AT2PW/T68XLfWzIb2yKcQSYJqNiLJeQko6WDdLuL/Lw1I8j0/anlhZiOB7wHTwhrJH1N4n1TEjuada5MEShZTshFJziPAvmHNA4DwMtdkoAE4xsz2NbMCwpGBU7Q/QfLZHtY4vhqWrweGmdk/hcccGE6F8QHBdAiJPEXbgLJlQFIdGESipGQjkoRwdN8zgOlh1+eXgP8G/uHurxPMc/Ji+PxcF95/TbjfOuDXwJNh+afAOcCNZrYGeIigxvMoQYKrN7Nz2r3dpcC/mtnzwHlARarxiPQ0dX0WEZHIqWYjIiKRU7IREZHIKdmIiEjklGxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCL3/wGAybD9KMdRCAAAAABJRU5ErkJggg==
+<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4xLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvAOZPmwAAIABJREFUeJzt3X94VNW97/H3N4hiLBJURB4pCVp/IL8CyfGIPYgItdRWoVZrPalC9Rye4q8Yb632cKq0vZyjtdcQlF6bVgUlVYrayrVWKyr1J9agQRFBUAFRqxGFIyII5Hv/2DthJkzITJI9M5l8Xs8zz8xee+/Z39kM883aa+21zN0RERGJUl6mAxARkdynZCMiIpFTshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkREIrdfpgPIlMMOO8yLiooyHYaISKeybNmyj9y9T6r7ddlkU1RURG1tbabDEBHpVMxsfVv202U0ERGJnJKNiIhETslGREQi12XbbERkj507d7Jx40a2b9+e6VAkS/To0YP+/fvTvXv3Dnk/JRsRYePGjfTs2ZOioiLMLNPhSIa5O5s2bWLjxo0MHDiwQ95Tl9FEhO3bt3PooYcq0QgAZsahhx7aoTVdJRsRAVCikTgd/X1QshERkcgp2YhI1ioqKuKjjz4C4Etf+lKb3mPJkiX06tWLESNGcNxxx3HKKafw0EMPNa2fMWMGRx55JMXFxRx//PFMmzaNhoaGDolf9lCyEZGcN3r0aF5++WVWr17N7Nmzueyyy3j88ceb1ldUVFBXV8fKlSt59dVX+dvf/pbBaHOTko2IpKymBoqKIC8veK6paf97Tpo0iZKSEgYPHkx1dXWL27k7V199NUOGDGHo0KEsWLAAgAsvvJA//elPTduVlZXx4IMP7rV/cXEx1113Hbfeeute67744gu2b99O79692/+BJI6SjYikpKYGpk6F9evBPXieOrX9CeeOO+5g2bJl1NbWMnv2bDZt2pRwuwceeIC6ujqWL1/O4sWLufrqq3n//fe5+OKLmTt3LgBbtmzhueee45vf/GbC9xg5ciSrVq1qWq6srKS4uJh+/fpx7LHHUlxc3L4PI3tRshGRlEyfDtu2xZdt2xaUt8fs2bMZPnw4J510Eu+88w5r1qxJuN0zzzzD+eefT7du3ejbty9jxozhxRdfZMyYMaxZs4b6+nruuecevvOd77DffolvJXT3uOXGy2gffvghn332Gffee2/7PozsRclGRFKyYUNq5clYsmQJixcv5vnnn2f58uWMGDGiTfd4XHjhhcyfP58777yTiy66qMXtXn75ZQYNGrRXeffu3ZkwYQJPPfVUyseWfVOyEZGUDBiQWnkytmzZQu/evcnPz2fVqlUsXbq0xW1Hjx7NggUL2L17N/X19Tz11FOceOKJAEyZMoVZs2YBcMIJJyTc/5VXXuEXv/gFl1566V7r3J1nn32Wo48+uu0fRhLScDUikpKZM4M2mthLafn5QXlbTZgwgdtuu41BgwZx3HHHcdJJJ7W47be//W2ef/55hg8fjpnxy1/+kiOOOAKAvn37MmjQICZNmhS3z9NPP82IESPYtm0bhx9+OLNnz2bcuHFN6ysrK5k/fz47d+5k2LBhXHLJJW3/MJKYu2fFA5gArAbWAtcmWH8AsCBc/wJQFLPuJ2H5auDryR2vxAsL3efPd5Eub+XKlSltP3++e2Ghu5ln1f+jzz77zI866ijfvHlzpkPJCbHfi8Z/cyhxb8NvfFZcRjOzbsAc4BvACcD5Zta8Dnwx8Im7fwWoBG4M9z0B+B4wmCBh/Tp8v1Z1VC8aka6mrAzWrYOGhuC5rCzTEcHixYsZNGgQl19+Ob169cp0ODkltgdiW2VFsgFOBNa6+1vu/gVwLzCx2TYTgXnh6/uAcRYM3jMRuNfdd7j72wQ1nBOTPXBH9KIRkcwbP34869ev58orr8x0KDknUQ/EVGVLsjkSeCdmeWNYlnAbd98FbAEOTXJfAMxsqpnVmlkt1DeVt6cXjYhIruuI38hsSTZp4e7V7l7q7qXQp6m8Pb1oRERyXUf8RmZLsnkX+HLMcv+wLOE2ZrYf0AvYlOS+LWpvLxoRkVw3c2bwW9ke2ZJsXgSOMbOBZrY/QYP/ombbLAImh6/PAZ5wdw/Lv2dmB5jZQOAY4O/JHLSwEKqrs6NxU0QkW5WVBb+VhYVtf4+sSDZhG8xlwKPA68Af3P01M/u5mZ0VbnY7cKiZrQWuAq4N930N+AOwEngEuNTdd7d2zJKS7OlFIyKJ3Xbbbdx1110AzJ07l/fee6/Fba+77joWL17cpuPU1dXx8MMPNy0vWrSIG264oU3v1dznn3/OmDFj2L07+Fm6+uqrGTx4MFdffXXc55syZQr33XcfALNmzWJbe1vk96Fxuob6+nomTJiQ1D6NPRBh2bI2HbQt/aVz4VFSUtJKD3ORriPV+2y8oWHfyxEYM2aMv/jiiwnX7dq1q13vfeedd/qll17arvdoya233uqzZs1qWj744IMTxjt58mRfuHChu7sXFhZ6fX19SsdJ5RwcdNBBTa+nTJnizzzzTMLtEn0vgFrvrPfZiEgnMmMGVFQEQz5D8FxREZS3w1133cWwYcMYPnw4F1xwQXioGfzqV7/ivvvuo7a2lrKyMoqLi/n8888pKirimmuuYeTIkSxcuDCuZlBUVMT111/PyJEjGTp0aNMIz3//+98ZNWoUI0aM4OSTT2b16tV88cUXXHfddSxYsIDi4mIWLFjA3LlzueyyywBYt24dp512GsOGDWPcuHFsCLtmTZkyhSuuuIKTTz6Zo446qunYzdXU1DBxYnAnx1lnncXWrVspKSlhwYIFTZ8v1uzZs3nvvfcYO3YsY8eOBeCvf/0ro0aNYuTIkZx77rls3bq16XPGnoM333yTCRMmUFJSwujRo5s+99tvv82oUaMYOnQo//mf/xl3vEmTJlGTjpsN25KhcuGhmo3IHknXbBoa3MvL3SF4TrTcBitWrPBjjjmm6a/5TZs2ubv79ddf7zfddJO7712zKSws9BtvvLFpuXnNYPbs2e7uPmfOHL/44ovd3X3Lli2+c+dOd3d/7LHH/Oyzz3b3vWs2scvf+ta3fO7cue7ufvvtt/vEiRObjnfOOef47t27/bXXXvOjjz56r8+1Y8cO79u3b1xZbK0i9vO1VLOpr6/30aNH+9atW93d/YYbbvCf/exnCc/Baaed5m+88Ya7uy9dutTHjh3r7u5nnnmmz5s3z92DmlZsDBs3bvQhQ4bsFbt7x9ZsNDaaiCTPDCorg9dVVcEDoLw8KDdr09s+8cQTnHvuuRx22GEAHHLIIUntd95557W47uyzzwagpKSEBx54AAgG/Jw8eTJr1qzBzNi5c2erx3j++eeb9r/gggv48Y9/3LRu0qRJ5OXlccIJJ/DBBx/ste9HH31EQUFBUp+lJUuXLmXlypV89atfBYIJ3kaNGtW0vvEcbN26leeee45zzz23ad2OHTsAePbZZ7n//vubPsM111zTtM3hhx++z7awjqJkIyKpaUw4jYkG2pVo2uOggw5qcd0BBxwAQLdu3di1axcAP/3pTxk7dix//OMfWbduHaeeemq7jt94DNh7jhyAAw88sE1TJcRyd772ta9xzz33JFzfeA4aGhooKCigrq4u4XbWwr/P9u3bOfDAA9sVYzLUZiMiqWlso4kV24bTBqeddhoLFy5smp3z448/3mubnj178umnn7b5GBDUbI48MhhgpHFWz9be++STT26aTK2mpobRo0cnfbzevXuze/fulBNObDwnnXQSzz77LGvXrgXgs88+44033thrn4MPPpiBAweycOFCIEhSy5cvB+CrX/1q3GeI9cYbbzBkyJCU4msLJRsRSV5joqmqCi6dNTQEz1VV7Uo4gwcPZvr06YwZM4bhw4dz1VVX7bXNlClT+OEPf9jUQaAtfvzjH/OTn/yEESNGNNV2AMaOHcvKlSubOgjEuuWWW7jzzjsZNmwYd999N1WxNboknH766TzzzDMp7TN16lQmTJjA2LFj6dOnD3PnzuX8889n2LBhjBo1Km5K61g1NTXcfvvtDB8+nMGDB/Pggw8CUFVVxZw5cxg6dCjvvht/z/uTTz7Z4vTZHckSVf26gtLSUq+trc10GCJZ4fXXX084c2VCM2bA5s17Lp01JqCCgnb3SMtFL730EpWVldx9992ZDiWhU045hQcffJDevXvvtS7R98LMlrl7aarHUZuNiKRmxowgwTS2ATS24WSgzaYzGDlyJGPHjmX37t1065bU7CdpU19fz1VXXZUw0XQ0JRsRSV3zxKJEs08XXXRRpkNIqE+fPnvNahoVtdmICJC4N5V0XR39fVCyERF69OjBpk2blHAECBLNpk2b6NGjR4e9py6jiQj9+/dn48aN1NfXt76xdAk9evSgf//+HfZ+SjbSecQ2Sidaljbr3r07AwcOzHQYksN0GU06h4gGfxSR9FCykeznHtzXEXvjYOONhZs3t+vOdRFJD11Gk+wX0eCPIpI+GkFAOg93yIupjDc0KNGIpFlbRxDQZTTpHCIY/DHb1NRAUVGQT4uKgmWRXKFkI9kvosEfs0lNDUydCuvXBx9n/fpgWQlHcoXabCT7mQWDPMa20TS24RQU5MSltOnTYdu2+LJt24LysrLMxCTSkdRmI51HDt9nk5eXuIJmFlTkRLKF2mwk9+Xw4I8DBqRWLtLZKNmIZIGZMyE/P74sPz8oF8kFSjYiWaCsDKqrobAwqLAVFgbLaq+RXKEOAiJZoqxMyUVyl2o2IiISOSUbERGJnJKNiIhETslGREQip2QjIiKRU7IREZHIZTzZmNkhZvaYma0Jn3u3sN3kcJs1ZjY5pnyJma02s7rwcXj6ohcRkWRkPNkA1wKPu/sxwOPhchwzOwS4Hvhn4ETg+mZJqczdi8PHh+kIWkREkpcNyWYiMC98PQ+YlGCbrwOPufvH7v4J8BgwIU3xiYhIO2VDsunr7u+Hr/8B9E2wzZHAOzHLG8OyRneGl9B+apZDozOKiOSItAxXY2aLgSMSrJoeu+DubmapznlQ5u7vmllP4H7gAuCuFuKYCkwFGKDhdEVE0iYtycbdx7e0zsw+MLN+7v6+mfUDErW5vAucGrPcH1gSvve74fOnZvZ7gjadhMnG3auBagjms0n9k4iISFtkw2W0RUBj77LJwIMJtnkUON3MeocdA04HHjWz/czsMAAz6w58C1iRhphFRCQF2ZBsbgC+ZmZrgPHhMmZWama/A3D3j4FfAC+Gj5+HZQcQJJ1XgDqCGtBv0/8RRERkXzQttIiIJE3TQouISNZSshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkQypqYGioogLy94rqnJdEQSlbSMjSYi0lxNDUydCtu2Bcvr1wfLAGVlmYtLoqGajYhkxPTpexJNo23bgnLJPUo2IpIRGzakVi6dW8rJxswOMrNuUQQjIl1HS1NKaaqp3NRqsjGzPDP7VzP7s5l9CKwC3jezlWZ2k5l9JfowRSTXzJwJ+fnxZfn5QbnknmRqNk8CRwM/AY5w9y+7++HAvwBLgRvN7PsRxigiOaisDKqrobAQzILn6mp1DshVrU4xYGbd3X1ne7fJNppiQEQkdZFNMRCbRMLZMPe5jYiISHNJ32cTzpr5TTPbBbwHvAK84u63RBWciIjkhlRu6hwN9Hf33WZ2JDAcGBZNWCIikktSSTYvAIcCH7r7u8C7wMORRCUiIjkllftsfgP8zcx+ZGajzaxXVEGJiEhuSSXZzAfuIqgNXQI8Z2ZvRhKViIjklFQuo2109/+OLTCzAzo4HhERyUGp1GzqzKw8tsDdd3RwPCIikoNSqdn0Bcab2TXAS8ByoM7dF0YSmYiI5Iykk427fxeaLp0NBoYC/wwo2YiIyD6lclPnIUAFcDiwErjL3edFFZh0Eu7BwFYtLYuIkFqbzb3Ap8D/A/KBZ8zsxEiiks5hxgyoqAgSDATPFRVBuYhIjFSSTR93/6W7PxT2SjsTmB1RXJLt3GHzZqiq2pNwKiqC5c2b9yQgERFS6yDwsZkNdfdXAdz9LTPLb20nyVFmUFkZvK6qCh4A5eVBuS6liUiMVqcYaNrQ7HjgPuBp4FXgBOBId/92dOFFR1MMdBB3yIupIDc0KNGI5LDIphiIsR0YSTCZ2uEEXZ/PT/WAkkMaL53Fim3DEREJpZJsHnD3L9z9D+4+w91/CxS3NwAzO8TMHjOzNeFz7xa2e8TMNpvZQ83KB5rZC2a21swWmNn+7Y1JkhDbRlNeHtRoysvj23BEREKtJhsz+66Z3QD0NLNBZha7T3UHxHAt8Li7HwM8Hi4nchNwQYLyG4FKd/8K8AlwcQfEJK0xg4KC+DaayspguaBAl9JEJE4y00IfCYwDbgZeBI4DNhNMoNbH3f+5XQGYrQZOdff3zawfsMTdj2th21OBH7n7t8JlA+qBI9x9l5mNAma4+9dbO67abDqI7rMR6VLa2mbTam+0cO6au8zsTXd/NjzYoUARsCrVAybQ193fD1//g2BYnGQdCmx2913h8kbgyA6ISZLVPLEo0YhIAql0fV5lZtMIOgq8Brzq7p8ns6OZLQaOSLBqeuyCu7uZRXax38ymAlMBBgwYENVhRESkmVSSzR+BxcA04A1glJm95e7Ht7aju49vaZ2ZfWBm/WIuo32YQkybgAIz2y+s3fQnmEG0pTiqCduZSktL1YItIpImqfRG6+nuPwc+cPcxBN2e/9ABMSwCJoevJwMPJrujBw1OTwLntGV/ERFJj1TvswHYYWYHuvv9wOkdEMMNwNfMbA0wPlzGzErN7HeNG5nZ0wQjTI8zs41m1tgJ4BrgKjNbS9CGc3sHxCQiIh0olctovwpHfl4A3GFmzwEF7Q3A3TcR9HZrXl4L/FvM8ugW9n8L0ICgIiJZLJn7bEaZmbn7/e7+sbvfDPwF+DJwduQRiohIp5dMzeZCYI6ZvQE8Ajzi7ndFG5aIiOSSZO6zmQZNA3F+A5hrZr0IGuYfAZ51992RRikiIp1aMpfRBgG4+yp3r3T3CcBpwDPAucAL0YYoIiKdXTKX0f5sZn8DrnP3dwDCmzkfDh8iIiL7lEzX5+OBl4CnzKzKzPpEHJOIiOSYVpNNOK3ALcAg4B3g72b2CzM7OPLoRETaqKYGioqCuf2KioJlyZykb+p09+3u/itgCPA5sMzMfhRZZCIibVRTA1Onwvr1wUDk69cHy0o4mZN0sjGzIjObQHCj5QDgU+C/ogpMRKStpk+Hbdviy7ZtC8olM1rtIGBmrxAM27+BYEqB1wkmObuVYEBOEZGssmFDauUSvWR6o00C3vbWZlkTEckSAwYEl84SlUtmJNNB4K1wnpljzOx2M7s1HYGJiLTVzJmQnx9flp8flEtmpDLq893AfcApAGY2xMw0bI2IZJ2yMqiuhsLCYPLYwsJguaws05F1XamM+pzn7n8xs/8CcPcVZjYkorhERNqlrEzJJZukUrN5z8wGAg5gZgYcGElUIiKdTfNmbTVzx0kl2VwJ/BY4wsx+ANwLrIgkKhGRzmTGDKio2JNg3IPlGTMyGVVWSeWmznXABOAK4Cjgb8AF0YQlItJJuMPmzVBVtSfhVFQEy5s3q4YTSuY+G2vs9uzuuwg6CdzX0jYiIl2KGVRWBq+rqoIHQHl5UG6WudiySDI1myfN7HIzi+uhbmb7m9lpZjYPmBxNeCIinUBswmmkRBMnmWQzAdgN3GNm75nZSjN7G1gDnA/Mcve5EcYoIpLdGi+dxYptw5GkZurcDvwa+LWZdQcOAz53981RBycikvVi22gaL501LoNqOKFk2myOA97wwE7g/ejDEumC3ON/lJovS3Yyg4KC+DaaxktqBQX6NwxZa+36ZvYqUEgw6OYrwKuNz+7+YeQRRqS0tNRra2szHYZIYMaMoOdS449V41/LBQXqPttZdJE/FsxsmbuXprpfMmOjDQX6ANOAMwm6Pf8H8IqZ/SPVA4pIM+o6mxuaJ5YcTDTtkdRwNe6+A3jRzLa6++WN5WbWO7LIRLoKdZ2VLiCVEQQgHKqmacH9kw6MRaTrUtdZyXGtJhszm2NmF5vZCEDffJEoqOus5LhkajbLgWJgFtAzvM9moZn9zMzOizY8kS6gedfZhobgObYNR6STS+Y+m+rYZTPrDwwDSoALgQXRhCbSRajrrHQBrXZ9jts4uJR2PvA9gvttjnf3XhHFFil1fZas00W6zkrn1tauz8nc1HksQYL5V2Ar8AdgjLu/HQ5bIyIdQV1nJYcl0/V5FfAicI67v9psnS4mi4hIq5LpIHA28DbwVzO728zODMdI6xBmdoiZPWZma8LnhPfumNkjZrbZzB5qVj7XzN42s7rwUdxRsYmISMdIZgSBP7n794CvAH8BpgIbzexO4OAOiOFa4HF3PwZ4PFxO5CZanqztancvDh91HRCTiIh0oFRm6vzM3X/v7mcCxwPPE4yR1l4TgXnh63nApBaO/zjwaQccT0RE0izVEQSAYOQAd69299M6IIa+7t44kvQ/gL5teI+ZZvaKmVWa2QEtbWRmU82s1sxq6+vr2xSsiIikrk3JJlVmttjMViR4TIzdLpxaOtVOBz8hqGn9E3AIcE1LG4YJstTdS/v06ZPqx5BMa95NXzc7pk1NDRQVQV5e8FxTk+mIpLNJaiDO9nL38S2tM7MPzKyfu79vZv2AlKYtiKkV7QjbkX7UjlAlW2kI/oypqYGpU2HbtmB5/fpgGaCsLHNxSeeSlppNKxYBk8PXk4EHU9k5TFCYmRG096zo0Ogk89IxBL9qTS2aPn1Pomm0bVtQLpKslEYQiCQAs0MJbhQdAKwHvuvuH5tZKfBDd/+3cLunCS6XfQnYBFzs7o+a2RME8+0YUBfus7W142oEgU4mNsE06qgh+FVr2qe8vMS51ywYxk26lsgmT4uau29y93Hufoy7j3f3j8Py2sZEEy6Pdvc+7n6gu/d390fD8tPcfai7D3H37yeTaKQTMuOSHfFD8F+yowMSjSYua9WAAamViySS8WQjkoxLpjnH3hY/BP+xt1VwybR2JoNw0MtVXw9HWc7Lg6qqYLmLzifTvDPAGWdAfn78Nvn5MHNmJqKTzkrJRrKfO8f9poIrqWIW5RgNzKKcK6niuN+0fwj+mt8bJU/F15pKnqqk5vddM9FMnRp0AnAPnufNg8mTobAwyL2FhVBdrc4Bkpq09EYTaRczPvECZlFOBZWAhc+w2ds/BP/0/3Bmfh5fa5r5eQXT/6OSsrKulXBa6gzw8MOwbl1GQmo7jaKdVTLeQSBT1EGgc9lvP9i924mfLNbp1s3Ytasdb+xOVV4F5WGtqYJKKglqUVWUU97QtS6l5UxnAHX6iEyn7SAgkozgvo7mP/rWdL9Hm5nhvfauNc2iHO/V9SYuy4nOAOr0kZ3cvUs+SkpKXDqXadPcu3Vzh+B52rSOed/5893zD2zw4FcoeOQf2ODz53fM+3cm8+e75+d7/LnI9853Lhoa3MvL4z9IeXlQLu0C1HobfnN1GU2EoGF8+nTYsCH4K37mzK7bAJ4z58I9uC7YqKGhy9VUo9DWy2hKNiKSe9xZ9Y0Kjn90z03Aq75ezvF/6VptcFFQm42ICMQlmtiu8sc/WsWqb7S/q7y0jbo+i0huMeORpQU8kqCrPEsLOF41m4zQZTQRyTlBF+69u8qbWefqwp2FdBlNRCQUdNXeu6t8p+rCnWOUbKTz0DQAkqSZMzWeW7ZRspHOYcaMPTfowZ4b9XQ3uCRQVhaM36bx3LKHko1kv5g7wu/oVUGeOXf00h3hsm9lZcF4bg0NwbMSTWapN5pkPzNqSivZ3M259NMqLqIKPoU53a6goLSSMvUukkQ0EGdWUc1GOoX6y37Gzt3xZTt3B+Uie9Fl16yjZCPZzx3b8glXMjuu+EpmY1s+0WU0iaeBOLOSLqNJp9CzJ/BpC+UiscLZV4EgwVSFQ9aUd93ZV7OBajaS/cwoHd+bOd2uiCue0+0KSsf31o+H7C024TRSoskoJRvpFIbdfz3jxsWXjRsXlIvspfHSWawKjYuWSUo2kv3CH47j/zo7uBTS0ADl5cGyfkCkudg2mpjvS1wbjqSd2mwk+5kF0/nGXnNvvERS0PVm05RWNH5fLr88/vvS0KDvSwYp2UjnMGNG/H0SjT8g+uGQRJYsgS1b9nxn3OHpp6FXr0xH1mXpMpp0Hs0TixKNJNLQECSaujpe61FCnjXwWo8SqKsLyjXsc0Yo2YhIbsnLo+aqZSy3YgbvrKOBbgzeWcdyK6bmqmXxU0VL2mg+GxHJOUVFsH59A063pjJjN4WFeaxbl7GwcoLmsxERCW1Y38BLlMSVvUQJG9brElqmKNmISG5paODV7iWMoI6XKcbYzcsUM4I6Xu1eojabDFGyEckWmhyuY+TlcdjRvVhuxYxkGZDHSII2nMOO7qU2mwzRWRfJBhqluEP1fX0JK+Yto7AwL5w8LY8V85bR9/UlmQ6ty8p4sjGzQ8zsMTNbEz73TrBNsZk9b2avmdkrZnZezLqBZvaCma01swVmtn96P4FIO2mU4kiUXZAXP3naBRn/uevSsuHsXws87u7HAI+Hy81tAy5098HABGCWmRWE624EKt39K8AnwMVpiFmk4zTeoNo4pEpe3p6hVnTjquSIjHd9NrPVwKnu/r6Z9QOWuPtxreyzHDgHWAvUA0e4+y4zGwXMcPevt3ZcdX2WrOMe357Q0KBEI1mnM3d97uvu74ev/wH03dfGZnYisD/wJnAosNndd4WrNwJHRhWoSGQ0SrHkuLQkGzNbbGYrEjwmxm7nQTWrxf9dYc3nbuAH7p5y/0Uzm2pmtWZWW19fn/LnEImERimWLiAtA3G6+/iW1pnZB2bWL+Yy2octbHcw8GdgursvDYs3AQVmtl9Yu+kPvLuPOKqBagguo7Xt04h0MI1qLV1ANoz6vAiYDNwQPj/YfIOwh9kfgbvc/b7Gcnd3M3uSoP3m3pb2F8l6GtVaclw2tNncAHzNzNYA48NlzKzUzH4XbvOXFxHjAAAIfElEQVRd4BRgipnVhY/icN01wFVmtpagDef29IYv0kE0qrXksIz3RssU9UYTyUKxtbtEy5Jxnbk3moiIRlHIcUo2IpJ5GkUh5ynZiGSLrjwQp1kwZXNxcfwoCsXFQbkupXV6SjYi2aCrX0Jyb5rKOU7jVM5dKfHmKCUbkUzTJaSg5nLzzXw8oDiu+OMBxXDzzarZ5AAlG5FM00Cc4M6qM67ikA3xNZtDNtSx6oyrukbCzXFKNiLZwIya0sq4oprSLpJoAMx45PlevEx8zeZlinnkebXZ5AIlG5EsUDPf2fyD+IE4N/+ggpr5XeQvenfsf7YwgjpmUY7RwCzKGUEd9j9qs8kFSjYimebOjksquHRXVdwP7aW7qthxSRcZiNMM71XALMqpoBIwKqhkFuV4L40PlwuyYWw0ka7NjHc+3fuHFmDLp13nh7bPnBlM/XeHzxs/rzH9wEqq53SNz5/rNFyNSBYoKoL16x2I/WF1CguNdesyE1Mm1NTA9OmwYQMMGAAzZ0JZWaajklgarkakE5s5E/Lz4/+Cz883Zs7MUEAZUlYG69YFU/qsW6dEk0uUbESyQFkZVFdDYWFw1aywMFjWj63kCrXZiGSJsjIlF8ldqtmIiEjklGxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCKnZCMiIpFTshERkcgp2YiISOSUbEREJHJKNiIiEjklGxERiZySjYiIRE7JRkREIqdkIyIikVOyERGRyJm7ZzqGjDCzT4HVmY4jSxwGfJTpILKEzsUeOhd76FzscZy790x1p648U+dqdy/NdBDZwMxqdS4COhd76FzsoXOxh5nVtmU/XUYTEZHIKdmIiEjkunKyqc50AFlE52IPnYs9dC720LnYo03nost2EBARkfTpyjUbERFJk5xPNmY2wcxWm9laM7s2wfoDzGxBuP4FMytKf5TRS+I8XGVmK83sFTN73MwKMxFnOrR2LmK2+46ZuZnlbC+kZM6FmX03/G68Zma/T3eM6ZLE/5EBZvakmb0c/j85IxNxpoOZ3WFmH5rZihbWm5nNDs/VK2Y2stU3dfecfQDdgDeBo4D9geXACc22uQS4LXz9PWBBpuPO0HkYC+SHr6fl4nlI9lyE2/UEngKWAqWZjjuD34tjgJeB3uHy4ZmOO4PnohqYFr4+AViX6bgjPB+nACOBFS2sPwP4C2DAScALrb1nrtdsTgTWuvtb7v4FcC8wsdk2E4F54ev7gHFmZmmMMR1aPQ/u/qS7bwsXlwL90xxjuiTznQD4BXAjsD2dwaVZMufi34E57v4JgLt/mOYY0yWZc+HAweHrXsB7aYwvrdz9KeDjfWwyEbjLA0uBAjPrt6/3zPVkcyTwTszyxrAs4TbuvgvYAhyalujSJ5nzEOtigr9aclGr5yK8JPBld/9zOgPLgGS+F8cCx5rZs2a21MwmpC269ErmXMwAvm9mG4GHgcvTE1pWSvU3pUuPICAJmNn3gVJgTKZjyQQzywNuBqZkOJRssR/BpbRTCWq7T5nZUHffnNGoMuN8YK67/x8zGwXcbWZD3L0h04F1Brles3kX+HLMcv+wLOE2ZrYfQfV4U1qiS59kzgNmNh6YDpzl7jvSFFu6tXYuegJDgCVmto7gevSiHO0kkMz3YiOwyN13uvvbwBsEySfXJHMuLgb+AODuzwM9CMZM64qS+k2JlevJ5kXgGDMbaGb7E3QAWNRsm0XA5PD1OcATHraA5ZBWz4OZjQB+Q5BocvW6PLRyLtx9i7sf5u5F7l5E0H51lru3aTyoLJfM/48/EdRqMLPDCC6rvZXOINMkmXOxARgHYGaDCJJNfVqjzB6LgAvDXmknAVvc/f197ZDTl9HcfZeZXQY8StDb5A53f83Mfg7Uuvsi4HaC6vBaggax72Uu4mgkeR5uAr4ELAz7R2xw97MyFnREkjwXXUKS5+JR4HQzWwnsBq5291yr+Sd7Lv4X8FszqyDoLDAlB/8wBcDM7iH4I+OwsI3qeqA7gLvfRtBmdQawFtgG/KDV98zRcyUiIlkk1y+jiYhIFlCyERGRyCnZiIhI5JRsREQkcko2IiISOSUbkSSZ2RFmdq+ZvWlmy8zsYTM7NoX9jzezunDU4KPbGUtx7KjDZnbWvkawFsk0dX0WSUI4OOtzwLzwPgPMbDhwsLs/neR7XAvs5+7/O8F7WyrDnpjZFILRqC9Ldh+RTFLNRiQ5Y4GdjYkGwN2Xu/vTZnaqmT3UWG5mt4bJgJiyM4ArgWnhnChF4dwpdwErgC+b2f81s9pw3pifxez7T2b2nJktN7O/m1kv4OfAeWFN6Twzm2Jmt4bbF5nZE7ZnbqIBYfnccA6S58zsLTM7J7rTJRJPyUYkOUOAZW3d2d0fBm4DKt19bFh8DPBrdx/s7uuB6e5eCgwDxpjZsHDolAVAubsPB8YDnwHXEcw5VOzuC5od7haCGtgwoAaYHbOuH/AvwLeAG9r6eURSldPD1YhkufXhXCCNvmtmUwn+X/YjmKDLgffd/UUAd/8fgFamXBoFnB2+vhv4Zcy6P4WX61aaWd8O+RQiSVDNRiQ5rwElLazbRfz/pR5JvudnjS/MbCDwI2BcWCP5cwrvk4rY0bxzbZJAyWJKNiLJeQI4IKx5ABBe5hoNrAdOMLMDzKyAcGTgFB1MkHy2hDWOb4Tlq4F+ZvZP4TF7hlNhfEowHUIiz7FnQNkyIKkODCJRUrIRSUI4uu+3gfFh1+fXgP8G/uHu7xDMc7IifH65De+/PNxvFfB74Nmw/AvgPOAWM1sOPEZQ43mSIMHVmdl5zd7ucuAHZvYKcAFQnmo8Ih1NXZ9FRCRyqtmIiEjklGxERCRySjYiIhI5JRsREYmcko2IiEROyUZERCKnZCMiIpFTshERkcj9f378IyDXUQvnAAAAAElFTkSuQmCC
 "
 >
 </div>
 
 </div>
 
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span> 
+</pre></div>
+
+    </div>
 </div>
 </div>
 

--- a/IntroQueries.ipynb
+++ b/IntroQueries.ipynb
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you are working through the notebooks in the order they are presented on our [API Examples](https://citrination.org/learn/api-examples/) site, use the `dataset_id` from the previous Importing VASP calculations notebook in the query below. \n",
+    "If you are working through the notebooks in the order they are presented in our [README](README.md), use the `dataset_id` from the previous Importing VASP calculations notebook in the query below. \n",
     "\n",
     "Otherwise, we can start with the [Bandgaps Dataset](https://citrination.com/datasets/1160/show_search), but feel free to use any public dataset.\n",
     "\n"
@@ -848,7 +848,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.2"
   },
   "nbpresent": {
    "slides": {

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Most of these tutorials are Jupyter notebooks backed by a python3 kernel.  You'l
    
    The API key functions as the password for the client, so it's important to keep it private.  It's a good practice to put it in your environment instead of in the source code to help avoid unintentional sharing or publication of your API key.
 
-## References
+## Additional Resources
 
 * The example data used in these tutorials is drawn from: [Alloy Database](http://alloy.phys.cmu.edu/) by Mihalkovic, Widom, and coworkers.
 
-* More API examples have also been developed by the Citrine [Community team](https://github.com/CitrineInformatics/community-tools/tree/master/api_examples).
+* [More API examples](https://github.com/CitrineInformatics/community-tools/tree/master/api_examples) have also been developed by the Citrine Community team.
+
+* If you're looking for tutorials for the Citrination web user interface, please see [this page](https://github.com/CitrineInformatics/community-tools/tree/master/web_ui_examples).


### PR DESCRIPTION
Since citrination.org is no longer being maintained, I wanted to clean up those links. The README also had a copy of the tutorial sequence, so it was redundant to begin with.