### PR TITLE
Pin ASE to 3.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas>0.18,<=0.23
 matplotlib<=3.0
 
 jupyter<=1.0
+ase==3.17.0


### PR DESCRIPTION
Future versions of ASE dropped python 2.x support, which we want to
preserve in this repository.